### PR TITLE
Added shop

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,10 +14,12 @@ import WorldMap from './map/WorldMap';
 import { PopupType } from './models/PopupMessage';
 import {
   activeDialog,
+  activeShop,
   battleState,
   gamePhase,
   popupMessage,
   setActiveDialog,
+  setActiveShop,
 } from './store/gameStore';
 import DialogBox from './story/DialogBox';
 import IntroSequence from './story/IntroSequence';
@@ -27,8 +29,10 @@ import IdleLandmarkScreen from './ui/IdleLandmarkScreen';
 import PartyPanel from './ui/PartyPanel';
 import PilotBattleScreen from './ui/PilotBattleScreen';
 import SettingsMenu from './ui/SettingsMenu';
+import ShopPanel from './ui/ShopPanel';
 import SuppliesPanel from './ui/SuppliesPanel';
 import WalletIndicator from './ui/WalletPanel';
+import { buyItem } from './store/inventoryStore';
 
 const App: Component = () => {
   let game: Game;
@@ -74,6 +78,13 @@ const App: Component = () => {
           <SettingsMenu />
         </div>
       </div>
+      <Show when={activeShop()}>
+        <ShopPanel
+          shop={activeShop()!}
+          onBuy={(item, amount) => buyItem(item.id, amount)}
+          onClose={() => setActiveShop(null)}
+        />
+      </Show>
       <Show when={showSupplies()}>
         <SuppliesPanel onClose={() => setShowSupplies(false)} />
       </Show>

--- a/src/game/Game.ts
+++ b/src/game/Game.ts
@@ -4,7 +4,7 @@ import { t } from '../i18n';
 import type { City, Landmark, Route } from '../landmark';
 import { Currency } from '../models/Currency';
 import type { Pilot } from '../models/Pilot';
-import { ActionFightPilot, ActionTalkToNPC, getCity, getLandmarkHints, getRoute, isLandmarkUnlocked, isRoute, ROUTES } from '../landmark';
+import { ActionFightPilot, ActionTalkToNPC, ActionVisitDepot, getCity, getLandmarkHints, getRoute, isLandmarkUnlocked, isRoute, ROUTES } from '../landmark';
 import { REGIONS } from '../map/Region';
 import { DEFAULT_PLAYER } from '../models/Player';
 import { PopupMessage, PopupType } from '../models/PopupMessage';
@@ -22,6 +22,7 @@ import {
   setPlayerStats,
   setShowClickHint,
   setActiveDialog,
+  setActiveShop,
   setPopupMessage,
 } from '../store/gameStore';
 import { setCurrentLandmark } from '../store/landmarkStore';
@@ -156,6 +157,8 @@ export class Game {
           setActiveDialog(action.script);
           checkCampaigns();
         };
+      } else if (action instanceof ActionVisitDepot) {
+        action.onExecute = () => setActiveShop({ items: action.items });
       }
     });
   }

--- a/src/i18n/locales/en/ui.json
+++ b/src/i18n/locales/en/ui.json
@@ -1,10 +1,12 @@
 {
+  "buy": "Buy",
   "choose": "Choose",
   "currency": "Loot",
   "choose_your_zoid": "Choose your Zoid",
   "click_hint": "Click to shoot your pilot weapon",
   "click_to_continue": "Click to continue...",
   "defeated": "Defeated!",
+  "depot": "Depot",
   "fight_pilot": "Fight {{name}}",
   "fights_completed": "Zoids Fights Completed",
   "locked": "Locked",
@@ -12,6 +14,7 @@
   "magnis": "Magnis",
   "lv": "Lv.",
   "manual_attack": "Manual Attack",
+  "max": "Max",
   "not_strong_enough": "You're not strong enough to defeat {{name}}. Upgrade your army and come back!",
   "pilot_defeated": "{{name}} has been defeated!",
   "settings": "Settings",
@@ -30,9 +33,11 @@
   "new_item": "New Item Obtained!",
   "operations": "Operations",
   "talk_to_npc": "Talk to {{name}}",
+  "total": "Total",
   "total_attack": "Total Zoids Attack",
   "unknown": "Unknown",
   "victory": "Victory!",
+  "visit_depot": "Visit Depot",
   "zoids_army": "Zoids Army",
   "zoids_defeated": "Zoids Defeated"
 }

--- a/src/i18n/locales/es/ui.json
+++ b/src/i18n/locales/es/ui.json
@@ -1,10 +1,12 @@
 {
+  "buy": "Comprar",
   "choose": "Elegir",
   "currency": "Botín",
   "choose_your_zoid": "Elige tu Zoid",
   "click_hint": "Haz clic para disparar tu arma de piloto",
   "click_to_continue": "Haz clic para continuar...",
   "defeated": "¡Derrotado!",
+  "depot": "Depósito",
   "fight_pilot": "Luchar contra {{name}}",
   "fights_completed": "Zoids Combatidos",
   "locked": "Bloqueado",
@@ -12,6 +14,7 @@
   "magnis": "Magnis",
   "lv": "Nv.",
   "manual_attack": "Ataque manual",
+  "max": "Máx",
   "not_strong_enough": "¡No eres lo suficientemente fuerte para derrotar a {{name}}. Mejora tu ejército y vuelve!",
   "pilot_defeated": "¡{{name}} ha sido derrotado!",
   "settings": "Ajustes",
@@ -30,9 +33,11 @@
   "new_item": "¡Nuevo objeto obtenido!",
   "operations": "Operaciones",
   "talk_to_npc": "Hablar con {{name}}",
+  "total": "Total",
   "total_attack": "Ataque total de Zoids",
   "unknown": "Desconocido",
   "victory": "¡Victoria!",
+  "visit_depot": "Visitar Depósito",
   "zoids_army": "Ejército Zoids",
   "zoids_defeated": "Zoids derrotados"
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1251,6 +1251,259 @@ body {
   font-weight: bold;
 }
 
+/* Depot Actions (top inside battle-area) */
+
+.city-depot-actions {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 1rem;
+}
+
+.city-depot-actions .city-action-btn {
+  border-color: #ffd700;
+  color: #ffd700;
+}
+
+.city-depot-actions .city-action-btn:hover {
+  background: #4a3a10;
+}
+
+/* Depot Shop */
+
+.shop-overlay {
+  align-items: flex-start;
+  background: rgb(0 0 0 / 60%);
+  display: flex;
+  inset: 0;
+  justify-content: center;
+  padding-top: 5rem;
+  position: fixed;
+  z-index: 100;
+}
+
+.shop-panel {
+  background: #16213e;
+  border: 2px solid #0f3460;
+  border-radius: 12px;
+  max-width: 500px;
+  padding: 1.25rem;
+  width: 90%;
+}
+
+.shop-header {
+  align-items: center;
+  border-bottom: 1px solid #0f3460;
+  display: flex;
+  justify-content: center;
+  margin-bottom: 1rem;
+  padding-bottom: 0.75rem;
+  position: relative;
+}
+
+.shop-title {
+  color: #00d4ff;
+  font-size: 1.1rem;
+  font-weight: bold;
+  text-transform: uppercase;
+}
+
+.shop-close {
+  background: none;
+  border: none;
+  color: #999;
+  cursor: pointer;
+  font-size: 1.2rem;
+  position: absolute;
+  right: 0;
+}
+
+.shop-close:hover {
+  color: #e94560;
+}
+
+.shop-wallet {
+  align-items: center;
+  display: flex;
+  gap: 0.4rem;
+  justify-content: center;
+  margin-bottom: 1rem;
+}
+
+.shop-wallet-icon {
+  height: 18px;
+  width: 18px;
+}
+
+.shop-wallet-amount {
+  color: #ffd700;
+  font-size: 1rem;
+  font-weight: bold;
+}
+
+.shop-items {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.shop-item {
+  align-items: center;
+  background: #1a1a2e;
+  border: 2px solid #0f3460;
+  border-radius: 8px;
+  color: #e0e0e0;
+  cursor: pointer;
+  display: flex;
+  gap: 0.75rem;
+  padding: 0.6rem 0.75rem;
+  text-align: left;
+  transition: border-color 0.2s;
+  width: 100%;
+}
+
+.shop-item:hover {
+  border-color: #00d4ff;
+}
+
+.shop-item-selected {
+  border-color: #00d4ff;
+  background: rgb(0 212 255 / 10%);
+}
+
+.shop-item-icon {
+  flex-shrink: 0;
+  height: 36px;
+  image-rendering: pixelated;
+  object-fit: contain;
+  width: 36px;
+}
+
+.shop-item-info {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 0.15rem;
+  min-width: 0;
+}
+
+.shop-item-name {
+  color: #fff;
+  font-size: 0.85rem;
+  font-weight: bold;
+}
+
+.shop-item-desc {
+  color: #999;
+  font-size: 0.7rem;
+}
+
+.shop-item-price {
+  align-items: center;
+  display: flex;
+  gap: 0.25rem;
+  white-space: nowrap;
+}
+
+.shop-item-price span {
+  color: #ffd700;
+  font-size: 0.85rem;
+  font-weight: bold;
+}
+
+.shop-price-icon {
+  height: 14px;
+  width: 14px;
+}
+
+.shop-buy-section {
+  border-top: 1px solid #0f3460;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding-top: 0.75rem;
+}
+
+.shop-amount-row {
+  align-items: center;
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
+}
+
+.shop-amount-btn {
+  background: #0f3460;
+  border: 1px solid #00d4ff;
+  border-radius: 4px;
+  color: #00d4ff;
+  cursor: pointer;
+  font-size: 0.8rem;
+  font-weight: bold;
+  padding: 0.3rem 0.6rem;
+  transition: background 0.2s;
+}
+
+.shop-amount-btn:hover {
+  background: #1a4a8a;
+}
+
+.shop-amount-value {
+  color: #fff;
+  font-size: 1rem;
+  font-weight: bold;
+  min-width: 2.5rem;
+  text-align: center;
+}
+
+.shop-total-row {
+  align-items: center;
+  display: flex;
+  gap: 0.3rem;
+  justify-content: center;
+}
+
+.shop-total-label {
+  color: #999;
+  font-size: 0.85rem;
+}
+
+.shop-total-value {
+  color: #ffd700;
+  font-size: 1rem;
+  font-weight: bold;
+}
+
+.shop-no-funds {
+  color: #e94560;
+}
+
+.shop-buy-btn {
+  background: #0f3460;
+  border: 2px solid #00d4ff;
+  border-radius: 6px;
+  color: #00d4ff;
+  cursor: pointer;
+  font-size: 1rem;
+  font-weight: bold;
+  padding: 0.6rem;
+  transition: background 0.2s;
+  width: 100%;
+}
+
+.shop-buy-btn:disabled {
+  border-color: #333;
+  color: #555;
+  cursor: not-allowed;
+}
+
+.shop-buy-btn:hover:not(:disabled) {
+  background: #1a4a8a;
+}
+
 /* Mobile Responsive */
 
 @media (width <= 768px) {

--- a/src/landmark/City.ts
+++ b/src/landmark/City.ts
@@ -1,9 +1,10 @@
-import { ITEMS } from '../item';
+import { type ConsumableItem, ITEMS } from '../item';
 import { PILOTS } from '../models/Pilot';
 import { ItemRequirement, MissionCompletedRequirement, PilotDefeatRequirement, RouteKillRequirement } from '../requirement';
 import { addItem } from '../store/inventoryStore';
 import { ActionFightPilot } from './action/ActionFightPilot';
 import { ActionTalkToNPC } from './action/ActionTalkToNPC';
+import { ActionVisitDepot } from './action/ActionVisitDepot';
 import type { CityAction } from './action/CityAction';
 import type { Landmark } from './Landmark';
 import { BattleBackground, LandmarkType } from './Landmark';
@@ -29,6 +30,7 @@ export const CITIES: City[] = [
   },
   {
     actions: [
+      new ActionVisitDepot([ITEMS.core_probe as ConsumableItem], [new ItemRequirement(ITEMS.core_analyzer.id)]),
       new ActionTalkToNPC('boy', [new MissionCompletedRequirement('sleeper_commander', 'talk_to_hostage')]),
       new ActionTalkToNPC('captain_malinoff', [new MissionCompletedRequirement('sleeper_commander', 'talk_to_jenkins')], [new ItemRequirement(ITEMS.sleeper_module.id)]),
       new ActionTalkToNPC('jenkins', undefined, [new MissionCompletedRequirement('sleeper_commander', 'report_to_captain')], () => addItem(ITEMS.core_analyzer.id, 1, true)),

--- a/src/landmark/action/ActionVisitDepot.ts
+++ b/src/landmark/action/ActionVisitDepot.ts
@@ -1,0 +1,32 @@
+import { t } from '../../i18n';
+import type { ConsumableItem } from '../../item';
+import type { Requirement } from '../../requirement';
+import type { CityAction } from './CityAction';
+
+export class ActionVisitDepot implements CityAction {
+  id = 'depot';
+  items: ConsumableItem[];
+  onExecute: (() => void) | null = null;
+  requirements?: Requirement[];
+
+  constructor(items: ConsumableItem[], requirements?: Requirement[]) {
+    this.items = items;
+    this.requirements = requirements;
+  }
+
+  execute(): void {
+    this.onExecute?.();
+  }
+
+  getLabel(): string {
+    return t('ui:visit_depot');
+  }
+
+  isCompleted(): boolean {
+    return false;
+  }
+
+  isUnlocked(): boolean {
+    return this.requirements?.every((r) => r.isCompleted()) ?? true;
+  }
+}

--- a/src/landmark/action/index.ts
+++ b/src/landmark/action/index.ts
@@ -1,4 +1,5 @@
 export { ActionFightPilot } from './ActionFightPilot';
 export { ActionTalkToNPC } from './ActionTalkToNPC';
+export { ActionVisitDepot } from './ActionVisitDepot';
 export { isCityActionVisible } from './CityAction';
 export type { CityAction } from './CityAction';

--- a/src/landmark/index.ts
+++ b/src/landmark/index.ts
@@ -1,4 +1,4 @@
-export { ActionFightPilot, ActionTalkToNPC, isCityActionVisible } from './action';
+export { ActionFightPilot, ActionTalkToNPC, ActionVisitDepot, isCityActionVisible } from './action';
 export type { CityAction } from './action';
 export { CITIES, getCity } from './City';
 export type { City } from './City';

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -2,6 +2,7 @@ import { createMemo, createSignal } from 'solid-js';
 import type { PlayerStats } from '../models/Player';
 import type { PopupMessage } from '../models/PopupMessage';
 import type { DialogScript } from '../story/Dialog';
+import type { ShopData } from '../ui/ShopPanel';
 import type { ZoidInstance } from '../models/Zoid';
 
 export type BattleState = 'fighting' | 'idle' | 'pilot-fighting' | 'victory';
@@ -38,6 +39,7 @@ const [pilotZoidIds, setPilotZoidIds] = createSignal<string[]>([]);
 const [playerStats, setPlayerStats] = createSignal<PlayerStats | null>(null);
 const [showClickHint, setShowClickHint] = createSignal(true);
 const [activeDialog, setActiveDialog] = createSignal<DialogScript | null>(null);
+const [activeShop, setActiveShop] = createSignal<ShopData | null>(null);
 const [popupMessage, setPopupMessage] = createSignal<PopupMessage | null>(null);
 
 const enemyHealthPercent = createMemo(() => {
@@ -52,6 +54,7 @@ const pilotPlayerHealthPercent = createMemo(() => {
 
 export {
   activeDialog,
+  activeShop,
   battleState,
   damageEvents,
   enemyHealthPercent,
@@ -66,6 +69,7 @@ export {
   playerStats,
   rewardEvents,
   setActiveDialog,
+  setActiveShop,
   setBattleState,
   setDamageEvents,
   setGamePhase,

--- a/src/store/inventoryStore.ts
+++ b/src/store/inventoryStore.ts
@@ -1,11 +1,27 @@
 import { createSignal } from 'solid-js';
 import { t } from '../i18n';
-import { ItemType } from '../item';
+import { type ConsumableItem, ItemType } from '../item';
 import { ITEMS } from '../item';
+import { Currency } from '../models/Currency';
 import { PopupMessage, PopupType } from '../models/PopupMessage';
 import { setPopupMessage } from './gameStore';
+import { addCurrency, getCurrency } from './walletStore';
 
 const [inventory, setInventory] = createSignal<Record<string, number>>({});
+
+function buyItem(itemId: string, amount: number): boolean {
+  const item = ITEMS[itemId];
+  if (!item || item.type !== ItemType.Consumable) {
+    return false;
+  }
+  const total = (item as ConsumableItem).price * amount;
+  if (getCurrency(Currency.Magnis) < total) {
+    return false;
+  }
+  addCurrency(Currency.Magnis, -total);
+  addItem(itemId, amount);
+  return true;
+}
 
 function addItem(itemId: string, amount: number, unique = false): void {
   if (unique && getItemCount(itemId) > 0) {
@@ -18,6 +34,7 @@ function addItem(itemId: string, amount: number, unique = false): void {
       PopupType.Item,
       `images/items/${itemId}.png`
     ));
+    setTimeout(() => setPopupMessage(null), 3000);
   }
   setInventory((prev) => ({ ...prev, [itemId]: (prev[itemId] ?? 0) + amount }));
 }
@@ -42,4 +59,4 @@ function removeItem(itemId: string, amount: number): void {
   });
 }
 
-export { addItem, getItemCount, inventory, loadInventory, removeItem };
+export { addItem, buyItem, getItemCount, inventory, loadInventory, removeItem };

--- a/src/ui/IdleLandmarkScreen.tsx
+++ b/src/ui/IdleLandmarkScreen.tsx
@@ -1,11 +1,13 @@
 import { For, type Component } from 'solid-js';
 import { t } from '../i18n';
 import type { City } from '../landmark';
-import { isCityActionVisible } from '../landmark';
+import { ActionVisitDepot, isCityActionVisible } from '../landmark';
 import { currentLandmark, landmarkBackground } from '../store/landmarkStore';
 
 const IdleLandmarkScreen: Component = () => {
-  const actions = () => ((currentLandmark() as City).actions ?? []).filter(isCityActionVisible);
+  const visibleActions = () => ((currentLandmark() as City).actions ?? []).filter(isCityActionVisible);
+  const depotActions = () => visibleActions().filter((a) => a instanceof ActionVisitDepot);
+  const otherActions = () => visibleActions().filter((a) => !(a instanceof ActionVisitDepot));
 
   return (
     <div class="battle-screen">
@@ -15,8 +17,17 @@ const IdleLandmarkScreen: Component = () => {
           class="battle-area"
           style={{ 'background-image': `url('${landmarkBackground()}')`, 'background-size': 'cover' }}
         >
+          <div class="city-depot-actions">
+            <For each={depotActions()}>
+              {(action) => (
+                <button class="city-action-btn" onClick={() => action.execute()}>
+                  {action.getLabel()}
+                </button>
+              )}
+            </For>
+          </div>
           <div class="city-actions">
-            <For each={actions()}>
+            <For each={otherActions()}>
               {(action) => (
                 <button class="city-action-btn" onClick={() => action.execute()}>
                   {action.getLabel()}

--- a/src/ui/ShopPanel.tsx
+++ b/src/ui/ShopPanel.tsx
@@ -1,0 +1,94 @@
+import { type Component, createSignal, For } from 'solid-js';
+import { t } from '../i18n';
+import type { ConsumableItem } from '../item';
+import { Currency } from '../models/Currency';
+import { getCurrency } from '../store/walletStore';
+
+export interface ShopData {
+  items: ConsumableItem[];
+}
+
+interface ShopPanelProps {
+  onBuy: (item: ConsumableItem, amount: number) => void;
+  onClose: () => void;
+  shop: ShopData;
+}
+
+const ShopPanel: Component<ShopPanelProps> = (props) => {
+  const [selectedIndex, setSelectedIndex] = createSignal(0);
+  const [amount, setAmount] = createSignal(1);
+
+  const selectedItem = () => props.shop.items[selectedIndex()];
+  const totalPrice = () => selectedItem().price * amount();
+  const canAfford = () => getCurrency(Currency.Magnis) >= totalPrice();
+  const maxAffordable = () => {
+    const price = selectedItem().price;
+    return price > 0 ? Math.floor(getCurrency(Currency.Magnis) / price) : 0;
+  };
+
+  function buy(): void {
+    if (canAfford() && amount() > 0) {
+      props.onBuy(selectedItem(), amount());
+    }
+  }
+
+  return (
+    <div class="shop-overlay" onClick={() => props.onClose()}>
+      <div class="shop-panel" onClick={(e) => e.stopPropagation()}>
+        <div class="shop-header">
+          <span class="shop-title">{t('ui:depot')}</span>
+          <button class="shop-close" onClick={() => props.onClose()}>✕</button>
+        </div>
+        <div class="shop-wallet">
+          <img class="shop-wallet-icon" src="images/items/Magnis.png" alt="Magnis" />
+          <span class="shop-wallet-amount">{getCurrency(Currency.Magnis).toLocaleString()}</span>
+        </div>
+        <div class="shop-items">
+          <For each={props.shop.items}>
+            {(item, index) => (
+              <button
+                class={`shop-item ${selectedIndex() === index() ? 'shop-item-selected' : ''}`}
+                onClick={() => { setSelectedIndex(index()); setAmount(1); }}
+              >
+                <img class="shop-item-icon" src={`images/items/${item.id}.png`} alt={t(`items:${item.id}.name`)} />
+                <div class="shop-item-info">
+                  <span class="shop-item-name">{t(`items:${item.id}.name`)}</span>
+                  <span class="shop-item-desc">{t(`items:${item.id}.description`)}</span>
+                </div>
+                <div class="shop-item-price">
+                  <img class="shop-price-icon" src="images/items/Magnis.png" alt="" />
+                  <span>{item.price.toLocaleString()}</span>
+                </div>
+              </button>
+            )}
+          </For>
+        </div>
+        <div class="shop-buy-section">
+          <div class="shop-amount-row">
+            <button class="shop-amount-btn" onClick={() => setAmount((a) => Math.max(1, a - 1))}>−</button>
+            <span class="shop-amount-value">{amount()}</span>
+            <button class="shop-amount-btn" onClick={() => setAmount((a) => a + 1)}>+</button>
+            <button class="shop-amount-btn" onClick={() => setAmount((a) => a + 10)}>+10</button>
+            <button class="shop-amount-btn" onClick={() => setAmount(Math.max(1, maxAffordable()))}>{t('ui:max')}</button>
+          </div>
+          <div class="shop-total-row">
+            <span class="shop-total-label">{t('ui:total')}:</span>
+            <img class="shop-price-icon" src="images/items/Magnis.png" alt="" />
+            <span class={`shop-total-value ${canAfford() ? '' : 'shop-no-funds'}`}>
+              {totalPrice().toLocaleString()}
+            </span>
+          </div>
+          <button
+            class="shop-buy-btn"
+            disabled={!canAfford() || amount() <= 0}
+            onClick={buy}
+          >
+            {t('ui:buy')}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ShopPanel;


### PR DESCRIPTION
## Summary                                                                                                                                    

  Added a new "Depot" shop system as a city action type. The first depot is in Gleam Village, selling Core Probes for Magnis. The shop unlocks  after obtaining the Core Analyzer from Jenkins.
                                                                                                                                                
  ## What changed                                                                                                                             

  - New `ActionVisitDepot` city action type — shops that never "complete" (always visible once unlocked)                                        
  - `ShopPanel` overlay UI with item selection, quantity controls (−, +, +10, Max), price display, and buy button
  - Depot buttons render at the **top** of the city background image, styled in gold (#ffd700) to distinguish from NPC actions at the bottom    
  - `buyItem()` function in inventoryStore that validates funds, deducts Magnis, and adds items                                                 
  - Fixed pre-existing bug where item popups didn't clear from the DOM, preventing subsequent popups from showing                               
                                                                                                                                                
  ## Files                                                                                                                                      
                                                                                                                                                
  - **New:** `src/landmark/action/ActionVisitDepot.ts`, `src/ui/ShopPanel.tsx`                                                                  
  - **Modified:** `City.ts`, `Game.ts`, `IdleLandmarkScreen.tsx`, `App.tsx`, `gameStore.ts`, `inventoryStore.ts`, `index.css`, `en/ui.json`,
  `es/ui.json`                                                                                                                                  
                                                            
  ## How to test                                                                                                                                
                                                            
  1. Go to Gleam Village without a Core Analyzer → "Visit Depot" button should **not** appear                                                   
  2. Complete the campaign to obtain the Core Analyzer from Jenkins → golden "Visit Depot" button appears at the top of the city image
  3. Click "Visit Depot" → shop panel opens showing Core Probe with price and Magnis balance                                                    
  4. Adjust quantity and buy → Magnis deducted, probes appear in inventory (Supplies panel)                                                     
  5. Verify popup shows correctly for both Sleeper Module and Core Analyzer when obtained sequentially      