### PR TITLE
Added Zoid scan

### DIFF
--- a/src/game/Battle.ts
+++ b/src/game/Battle.ts
@@ -9,6 +9,7 @@ import { incrementRouteKills } from '../store/statisticsStore';
 import { addCurrency } from '../store/walletStore';
 
 import { BaseBattle } from './BaseBattle';
+import { attemptScan, getAvailableProbe } from './Scan';
 
 export class Battle extends BaseBattle {
   rewardIdCounter = 0;
@@ -36,6 +37,10 @@ export class Battle extends BaseBattle {
     addCurrency(Currency.Magnis, reward);
     setRewardEvents([...rewardEvents().slice(-4), { amount: reward, id: this.rewardIdCounter++ }]);
     incrementRouteKills(this.route.id);
+    const probe = getAvailableProbe();
+    if (probe) {
+      attemptScan(this.enemy.id, probe);
+    }
     checkCampaigns();
     this.spawnEnemy();
   }

--- a/src/game/Game.ts
+++ b/src/game/Game.ts
@@ -30,6 +30,7 @@ import { setParty } from '../store/partyStore';
 import { incrementPilotDefeats, loadStatistics } from '../store/statisticsStore';
 import { loadInventory } from '../store/inventoryStore';
 import { addCurrency, loadWallet } from '../store/walletStore';
+import { loadZoidData } from '../store/zoidDataStore';
 import { BaseBattle } from './BaseBattle';
 import { Battle } from './Battle';
 import { GameLoop } from './GameLoop';
@@ -178,6 +179,9 @@ export class Game {
       }
       if (data.wallet) {
         loadWallet(data.wallet);
+      }
+      if (data.zoidData) {
+        loadZoidData(data.zoidData);
       }
       loadCampaigns(CAMPAIGNS, data.campaigns ?? {});
       return true;

--- a/src/game/Save.ts
+++ b/src/game/Save.ts
@@ -7,6 +7,7 @@ import { party } from '../store/partyStore';
 import { pilotDefeats, routeKills } from '../store/statisticsStore';
 import { inventory } from '../store/inventoryStore';
 import { wallet } from '../store/walletStore';
+import { zoidDataLog } from '../store/zoidDataStore';
 const SAVE_KEY = 'zoids-sleeper-save';
 
 interface SaveData {
@@ -17,6 +18,7 @@ interface SaveData {
   pilotDefeats?: Record<string, number>;
   routeKills?: Record<string, number>;
   wallet?: Record<string, number>;
+  zoidData?: Record<string, number>;
 }
 
 export class Save {
@@ -44,6 +46,7 @@ export class Save {
       pilotDefeats: pilotDefeats(),
       routeKills: routeKills(),
       wallet: wallet(),
+      zoidData: zoidDataLog(),
     };
     localStorage.setItem(SAVE_KEY, JSON.stringify(data));
   }

--- a/src/game/Scan.ts
+++ b/src/game/Scan.ts
@@ -1,0 +1,48 @@
+import { t } from '../i18n';
+import { ITEMS, SyncDeviceItem } from '../item';
+import { PopupMessage, PopupType } from '../models/PopupMessage';
+import { getZoidById, getZoidImage } from '../models/Zoid';
+import { setPopupMessage } from '../store/gameStore';
+import { getItemCount, inventory, removeItem } from '../store/inventoryStore';
+import { party } from '../store/partyStore';
+import { getZoidDataCount, incrementZoidData } from '../store/zoidDataStore';
+
+export function attemptScan(zoidId: string, probeId: string): boolean {
+  const zoid = getZoidById(zoidId);
+  if (!canScan(probeId) || zoid.dropRate < 0) {return false;}
+
+  removeItem(probeId, 1);
+  const rate = calculateScanRate(zoidId, probeId);
+
+  if (Math.random() * 100 < rate) {
+    const isNew = getZoidDataCount(zoidId) === 0;
+    const inParty = party().some((z) => z.id === zoidId);
+    incrementZoidData(zoidId);
+    if (isNew && !inParty) {
+      const zoidData = getZoidById(zoidId);
+      setPopupMessage(new PopupMessage(zoidData.name, t('ui:new_zdata'), PopupType.Item, getZoidImage(zoidId)));
+      setTimeout(() => setPopupMessage(null), 3000);
+    }
+    return true;
+  }
+  return false;
+}
+
+export function calculateScanRate(zoidId: string, probeId: string): number {
+  const zoid = getZoidById(zoidId);
+  if (zoid.dropRate < 0) {return 0;}
+  const probe = ITEMS[probeId];
+  const bonus = probe instanceof SyncDeviceItem ? probe.successBonus : 0;
+  return Math.min(100, Math.max(0, zoid.dropRate + bonus));
+}
+
+export function canScan(probeId: string): boolean {
+  return getItemCount(probeId) > 0;
+}
+
+export function getAvailableProbe(): string | null {
+  const owned = inventory();
+  return Object.keys(owned)
+    .find((id) => owned[id] > 0 && ITEMS[id] instanceof SyncDeviceItem)
+    ?? null;
+}

--- a/src/i18n/locales/en/ui.json
+++ b/src/i18n/locales/en/ui.json
@@ -17,9 +17,12 @@
   "max": "Max",
   "not_strong_enough": "You're not strong enough to defeat {{name}}. Upgrade your army and come back!",
   "pilot_defeated": "{{name}} has been defeated!",
+  "scan_rate": "Scan rate: {{rate}}%",
   "settings": "Settings",
   "supplies": "Supplies",
   "supplies_empty": "No items yet",
+  "tab_items": "Items",
+  "tab_zdata": "Z-Data",
   "stat_attack": "Current Attack",
   "stat_attack_100": "Attack at Lv 100",
   "stat_base_attack": "Base Attack",
@@ -31,6 +34,7 @@
   "deploy": "Deploy",
   "mission_progress": "Mission {{current}}/{{total}}",
   "new_item": "New Item Obtained!",
+  "new_zdata": "New Z-Data Obtained!",
   "operations": "Operations",
   "talk_to_npc": "Talk to {{name}}",
   "total": "Total",
@@ -38,6 +42,7 @@
   "unknown": "Unknown",
   "victory": "Victory!",
   "visit_depot": "Visit Depot",
+  "zdata_empty": "No Z-Data collected yet",
   "zoids_army": "Zoids Army",
   "zoids_defeated": "Zoids Defeated"
 }

--- a/src/i18n/locales/es/ui.json
+++ b/src/i18n/locales/es/ui.json
@@ -17,9 +17,12 @@
   "max": "Máx",
   "not_strong_enough": "¡No eres lo suficientemente fuerte para derrotar a {{name}}. Mejora tu ejército y vuelve!",
   "pilot_defeated": "¡{{name}} ha sido derrotado!",
+  "scan_rate": "Prob. de análisis: {{rate}}%",
   "settings": "Ajustes",
   "supplies": "Suministros",
   "supplies_empty": "Sin objetos aún",
+  "tab_items": "Herramientas",
+  "tab_zdata": "Z-Data",
   "stat_attack": "Ataque actual",
   "stat_attack_100": "Ataque al Nv 100",
   "stat_base_attack": "Ataque base",
@@ -31,6 +34,7 @@
   "deploy": "Desplegar",
   "mission_progress": "Misión {{current}}/{{total}}",
   "new_item": "¡Nuevo objeto obtenido!",
+  "new_zdata": "¡Nueva Z-Data obtenida!",
   "operations": "Operaciones",
   "talk_to_npc": "Hablar con {{name}}",
   "total": "Total",
@@ -38,6 +42,7 @@
   "unknown": "Desconocido",
   "victory": "¡Victoria!",
   "visit_depot": "Visitar Depósito",
+  "zdata_empty": "Aún no has recolectado Z-Data",
   "zoids_army": "Ejército Zoids",
   "zoids_defeated": "Zoids derrotados"
 }

--- a/src/index.css
+++ b/src/index.css
@@ -147,6 +147,18 @@ body {
   background-color: rgb(0 212 255 / 5%);
 }
 
+.scan-rate {
+  color: #4fc3f7;
+  font-size: 0.85rem;
+  left: 50%;
+  margin: 0;
+  position: absolute;
+  text-shadow: 1px 1px 3px rgb(0 0 0 / 80%);
+  top: 0.5rem;
+  transform: translateX(-50%);
+  z-index: 2;
+}
+
 .enemy-image {
   max-height: 80%;
   max-width: 80%;
@@ -1148,9 +1160,36 @@ body {
   border-bottom: 1px solid #0f3460;
   display: flex;
   justify-content: center;
-  margin-bottom: 1rem;
+  margin-bottom: 0.75rem;
   padding-bottom: 0.75rem;
   position: relative;
+}
+
+.supplies-tabs {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.supplies-tab {
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: #999;
+  cursor: pointer;
+  flex: 1;
+  font-size: 0.9rem;
+  padding: 0.4rem 0;
+  transition: border-color 0.2s, color 0.2s;
+}
+
+.supplies-tab:hover {
+  color: #e0e0e0;
+}
+
+.supplies-tab--active {
+  border-bottom-color: #00d4ff;
+  color: #00d4ff;
 }
 
 .supplies-title {

--- a/src/models/Zoid.ts
+++ b/src/models/Zoid.ts
@@ -8,6 +8,7 @@ export interface OwnedZoid {
 export interface ZoidData {
   attack: number;
   baseExp: number;
+  dropRate: number;
   id: string;
   levelType: LevelType;
   maxHealth: number;
@@ -35,16 +36,16 @@ export interface ZoidStats {
 }
 
 export const ZOID_LIST: Record<string, ZoidData> = {
-  command_wolf: { attack: 200, baseExp: 50, id: 'command_wolf', levelType: LevelType.MediumFast, maxHealth: 200, name: 'Command Wolf' },
-  elephantus: { attack: 100, baseExp: 15, id: 'elephantus', levelType: LevelType.MediumSlow, maxHealth: 200, name: 'Elephantus' },
-  garius: {attack: 50, baseExp: 10, id: 'garius', levelType: LevelType.Fast, maxHealth: 100, name: 'Garius'},
-  gator: {attack: 150, baseExp: 35, id: 'gator', levelType: LevelType.MediumFast, maxHealth: 200, name: 'Gator'},
-  glidoler: {attack: 100, baseExp: 10, id: 'glidoler', levelType: LevelType.MediumFast, maxHealth: 40, name: 'Glidoler'},
-  malder: { attack: 20, baseExp: 40, id: 'malder', levelType: LevelType.Erratic, maxHealth: 700, name: 'Malder' },
-  merda: {attack: 50, baseExp: 20, id: 'merda', levelType: LevelType.Fast, maxHealth: 100, name: 'Merda'},
-  molga: { attack: 100, baseExp: 35, id: 'molga', levelType: LevelType.Fast, maxHealth: 400, name: 'Molga' },
-  tortoise: { attack: 100, baseExp: 30, id: 'tortoise', levelType: LevelType.Fast, maxHealth: 700, name: 'Cannon Tortoise' },
-  zatton: { attack: 120, baseExp: 40, id: 'zatton', levelType: LevelType.MediumSlow, maxHealth: 350, name: 'Zatton' },
+  command_wolf: { attack: 200, baseExp: 50, dropRate: 15, id: 'command_wolf', levelType: LevelType.MediumFast, maxHealth: 200, name: 'Command Wolf' },
+  elephantus: { attack: 100, baseExp: 15, dropRate: -1, id: 'elephantus', levelType: LevelType.MediumSlow, maxHealth: 200, name: 'Elephantus' },
+  garius: { attack: 50, baseExp: 10, dropRate: -1, id: 'garius', levelType: LevelType.Fast, maxHealth: 100, name: 'Garius' },
+  gator: { attack: 150, baseExp: 35, dropRate: 25, id: 'gator', levelType: LevelType.MediumFast, maxHealth: 200, name: 'Gator' },
+  glidoler: { attack: 100, baseExp: 10, dropRate: -1, id: 'glidoler', levelType: LevelType.MediumFast, maxHealth: 40, name: 'Glidoler' },
+  malder: { attack: 20, baseExp: 40, dropRate: 10, id: 'malder', levelType: LevelType.Erratic, maxHealth: 700, name: 'Malder' },
+  merda: { attack: 50, baseExp: 20, dropRate: 50, id: 'merda', levelType: LevelType.Fast, maxHealth: 100, name: 'Merda' },
+  molga: { attack: 100, baseExp: 35, dropRate: 20, id: 'molga', levelType: LevelType.Fast, maxHealth: 400, name: 'Molga' },
+  tortoise: { attack: 100, baseExp: 30, dropRate: 20, id: 'tortoise', levelType: LevelType.Fast, maxHealth: 700, name: 'Cannon Tortoise' },
+  zatton: { attack: 120, baseExp: 40, dropRate: 5, id: 'zatton', levelType: LevelType.MediumSlow, maxHealth: 350, name: 'Zatton' },
 };
 
 export function calculatePartyAttack(party: OwnedZoid[]): number {

--- a/src/store/zoidDataStore.ts
+++ b/src/store/zoidDataStore.ts
@@ -1,0 +1,17 @@
+import { createSignal } from 'solid-js';
+
+const [zoidDataLog, setZoidDataLog] = createSignal<Record<string, number>>({});
+
+function getZoidDataCount(zoidId: string): number {
+  return zoidDataLog()[zoidId] ?? 0;
+}
+
+function incrementZoidData(zoidId: string): void {
+  setZoidDataLog((prev) => ({ ...prev, [zoidId]: (prev[zoidId] ?? 0) + 1 }));
+}
+
+function loadZoidData(data: Record<string, number>): void {
+  setZoidDataLog(data);
+}
+
+export { getZoidDataCount, incrementZoidData, loadZoidData, zoidDataLog };

--- a/src/ui/BattleScreen.tsx
+++ b/src/ui/BattleScreen.tsx
@@ -1,4 +1,5 @@
 import { Show, type Component } from 'solid-js';
+import { calculateScanRate, getAvailableProbe } from '../game/Scan';
 import { t } from '../i18n';
 import { getZoidImage } from '../models/Zoid';
 import { enemyZoid, showClickHint } from '../store/gameStore';
@@ -19,6 +20,11 @@ const BattleScreen: Component<BattleScreenProps> = (props) => {
         <h2 class="enemy-name">{enemyZoid()?.name ?? t('ui:unknown')}</h2>
         <HealthBar />
         <div class={`battle-area bg-${battleBackground()}`} onClick={() => props.onClick()}>
+          <Show when={getAvailableProbe() && enemyZoid() && calculateScanRate(enemyZoid()!.id, getAvailableProbe()!) > 0}>
+            <p class="scan-rate">
+              {t('ui:scan_rate', { rate: calculateScanRate(enemyZoid()!.id, getAvailableProbe()!) })}
+            </p>
+          </Show>
           {enemyZoid()?.id && (
             <img class="enemy-image" src={getZoidImage(enemyZoid()!.id)} alt={enemyZoid()!.name} />
           )}

--- a/src/ui/SuppliesPanel.tsx
+++ b/src/ui/SuppliesPanel.tsx
@@ -1,16 +1,27 @@
-import { type Component, For, Show } from 'solid-js';
+import { type Component, createSignal, For, Show } from 'solid-js';
 import { t } from '../i18n';
+import { ZOID_LIST, getZoidImage } from '../models/Zoid';
 import { inventory } from '../store/inventoryStore';
+import { zoidDataLog } from '../store/zoidDataStore';
+
+type SuppliesTab = 'items' | 'zdata';
 
 interface SuppliesPanelProps {
   onClose: () => void;
 }
 
 const SuppliesPanel: Component<SuppliesPanelProps> = (props) => {
+  const [activeTab, setActiveTab] = createSignal<SuppliesTab>('items');
+
   const ownedItems = () =>
     Object.entries(inventory())
       .filter(([, count]) => count > 0)
       .map(([id, count]) => ({ count, id }));
+
+  const ownedZoidData = () =>
+    Object.entries(zoidDataLog())
+      .filter(([, count]) => count > 0)
+      .map(([id, count]) => ({ count, id, name: ZOID_LIST[id]?.name ?? id }));
 
   return (
     <div class="supplies-overlay" onClick={() => props.onClose()}>
@@ -21,32 +32,72 @@ const SuppliesPanel: Component<SuppliesPanelProps> = (props) => {
               ✕
           </button>
         </div>
-        <Show
-          when={ownedItems().length > 0}
-          fallback={<p class="supplies-empty">{t('ui:supplies_empty')}</p>}
-        >
-          <div class="supplies-grid">
-            <For each={ownedItems()}>
-              {(item) => (
-                <div class="supplies-item">
-                  <img
-                    class="supplies-item-icon"
-                    src={`images/items/${item.id}.png`}
-                    alt={t(`items:${item.id}.name`)}
-                  />
-                  <span class="supplies-item-count">×{item.count}</span>
-                  <div class="supplies-tooltip">
-                    <span class="supplies-tooltip-name">
-                      {t(`items:${item.id}.name`)}
-                    </span>
-                    <span class="supplies-tooltip-desc">
-                      {t(`items:${item.id}.description`)}
-                    </span>
+        <div class="supplies-tabs">
+          <button
+            class={`supplies-tab ${activeTab() === 'items' ? 'supplies-tab--active' : ''}`}
+            onClick={() => setActiveTab('items')}
+          >
+            {t('ui:tab_items')}
+          </button>
+          <button
+            class={`supplies-tab ${activeTab() === 'zdata' ? 'supplies-tab--active' : ''}`}
+            onClick={() => setActiveTab('zdata')}
+          >
+            {t('ui:tab_zdata')}
+          </button>
+        </div>
+        <Show when={activeTab() === 'items'}>
+          <Show
+            when={ownedItems().length > 0}
+            fallback={<p class="supplies-empty">{t('ui:supplies_empty')}</p>}
+          >
+            <div class="supplies-grid">
+              <For each={ownedItems()}>
+                {(item) => (
+                  <div class="supplies-item">
+                    <img
+                      class="supplies-item-icon"
+                      src={`images/items/${item.id}.png`}
+                      alt={t(`items:${item.id}.name`)}
+                    />
+                    <span class="supplies-item-count">×{item.count}</span>
+                    <div class="supplies-tooltip">
+                      <span class="supplies-tooltip-name">
+                        {t(`items:${item.id}.name`)}
+                      </span>
+                      <span class="supplies-tooltip-desc">
+                        {t(`items:${item.id}.description`)}
+                      </span>
+                    </div>
                   </div>
-                </div>
-              )}
-            </For>
-          </div>
+                )}
+              </For>
+            </div>
+          </Show>
+        </Show>
+        <Show when={activeTab() === 'zdata'}>
+          <Show
+            when={ownedZoidData().length > 0}
+            fallback={<p class="supplies-empty">{t('ui:zdata_empty')}</p>}
+          >
+            <div class="supplies-grid">
+              <For each={ownedZoidData()}>
+                {(entry) => (
+                  <div class="supplies-item">
+                    <img
+                      class="supplies-item-icon"
+                      src={getZoidImage(entry.id)}
+                      alt={entry.name}
+                    />
+                    <span class="supplies-item-count">×{entry.count}</span>
+                    <div class="supplies-tooltip">
+                      <span class="supplies-tooltip-name">{entry.name}</span>
+                    </div>
+                  </div>
+                )}
+              </For>
+            </div>
+          </Show>
         </Show>
       </div>
     </div>


### PR DESCRIPTION
 Summary                                                                                                                                                                                                 
                                                                                                                                                                                                          
  - Add Z-Data scan system: when defeating a Zoid on a route, if the player has a probe, it is consumed and a roll is made against the Zoid's dropRate. On success, Z-Data for that species is collected. 
  - Each Zoid species now has a dropRate (0-100). Starter Zoids (garius, glidoler, elephantus) use -1 (unscannable). Merda is easiest (50%), Zatton hardest (5%).                                         
  - New zoidDataStore tracks collected Z-Data per species, persisted in localStorage.                                                                                                                     
  - Battle screen shows scan rate percentage inside the battle area when a probe is available and the Zoid is scannable.                                                                                  
  - Supplies panel now has two tabs: Items and Z-Data, displaying collected data with Zoid images and counts.                                                                                             
  - First-time Z-Data popup notification when the Zoid is not already in the party.                                                                                                                       
  - Probe selection is dynamic via getAvailableProbe(), iterating over inventory to find the first available SyncDeviceItem.         