### PR TITLE
Fix cutscene advancing behind dialog and duplicate zoids in party 

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -147,18 +147,19 @@ const App: Component = () => {
       <Show when={showSupplies()}>
         <SuppliesPanel onClose={() => setShowSupplies(false)} />
       </Show>
-      <Show when={activeDialog()}>
-        <div class="dialog-overlay">
-          <DialogBox
-            script={activeDialog()!}
-            onComplete={() => {
-              const dialog = activeDialog();
-              if (dialog?.reward) {grantReward(dialog.reward);}
-              checkCampaigns();
-              setActiveDialog(dequeueDialog() ?? null);
-            }}
-          />
-        </div>
+      <Show when={activeDialog()} keyed>
+        {(dialog) => (
+          <div class="dialog-overlay">
+            <DialogBox
+              script={dialog}
+              onComplete={() => {
+                if (dialog.reward) {grantReward(dialog.reward);}
+                checkCampaigns();
+                setActiveDialog(dequeueDialog() ?? null);
+              }}
+            />
+          </div>
+        )}
       </Show>
       <Show
         when={gamePhase() === GamePhase.Playing}

--- a/src/models/Zoid.ts
+++ b/src/models/Zoid.ts
@@ -3,6 +3,7 @@ import { LevelType, levelFromExperience } from './LevelType';
 
 /** A zoid owned by the player, tracking accumulated experience. */
 export interface OwnedZoid {
+  copies?: number;
   experience: number;
   id: string;
 }

--- a/src/store/partyStore.ts
+++ b/src/store/partyStore.ts
@@ -9,7 +9,15 @@ const partyAttack = createMemo(() => calculatePartyAttack(party()));
 const partyMaxHealth = createMemo(() => calculatePartyMaxHealth(party()));
 
 function addZoidToArmy(zoidId: string, experience = 0): void {
-  setParty((prev) => [...prev, { experience, id: zoidId }]);
+  setParty((prev) => {
+    const existing = prev.find((z) => z.id === zoidId);
+    if (existing) {
+      return prev.map((z) => z.id === zoidId
+        ? { ...z, copies: (z.copies ?? 1) + 1 }
+        : z);
+    }
+    return [...prev, { experience, id: zoidId }];
+  });
   incrementClickAttack();
   updateZoidResearch(zoidId, ZoidResearchStatus.Created);
 }

--- a/test/PartyStore.test.ts
+++ b/test/PartyStore.test.ts
@@ -41,4 +41,32 @@ describe('PartyStore - addZoidToArmy', () => {
 
     expect(playerStats()!.clickAttack).toBe(2);
   });
+
+  it('should not add duplicate entry for the same zoid', () => {
+    addZoidToArmy('molga');
+    addZoidToArmy('molga');
+
+    expect(party().filter((z) => z.id === 'molga')).toHaveLength(1);
+  });
+
+  it('should increment copies when adding a duplicate zoid', () => {
+    addZoidToArmy('molga');
+    addZoidToArmy('molga');
+
+    expect(party().find((z) => z.id === 'molga')?.copies).toBe(2);
+  });
+
+  it('should still increment click attack on duplicate purchase', () => {
+    addZoidToArmy('molga');
+    addZoidToArmy('molga');
+
+    expect(playerStats()!.clickAttack).toBe(3);
+  });
+
+  it('should add different zoids as separate entries', () => {
+    addZoidToArmy('molga');
+    addZoidToArmy('gator');
+
+    expect(party()).toHaveLength(2);
+  });
 });


### PR DESCRIPTION
## Summary                                                                                                                                    
  - Fix cutscene dialog advancing behind NPC dialog by using `<Show keyed>` so the DialogBox remounts (resetting line index to 0) when       transitioning between dialogs (#55)                                                                                                           
  - Prevent duplicate zoid entries in the party panel when buying the same zoid multiple times from the lab; duplicates now increment a copies   counter instead of adding new entries (#54)                                                                                                   
                                                                                                                                                
  ## Test plan                                                                                                                                  
  - [x] All 142 tests pass (4 new tests for duplicate zoid prevention)
  - [x] Trigger "Interrogate bandits" at Elmia Ruins — cutscene should start from line 0 after the NPC dialog completes
  - [x] Buy the same zoid twice from a lab — only one entry should appear in the party panel                                                    
  - [x] Verify click attack still increases on duplicate purchases
  - [x] Load an existing save (without `copies` field) — should work normally         