### PR TITLE
Fix bandit fight skip and improve campaign texts (#74)

### DIFF
--- a/src/game/PilotBattle.ts
+++ b/src/game/PilotBattle.ts
@@ -36,6 +36,7 @@ export class PilotBattle extends BaseBattle {
   }
 
   protected onBattleTick(): void {
+    if (this.enemy.health <= 0) {return;}
     this.enemyAttack();
   }
 

--- a/src/i18n/locales/en/campaigns.json
+++ b/src/i18n/locales/en/campaigns.json
@@ -4,70 +4,70 @@
     "missions": {
       "beat_bandit": {
         "description": "You found an abandoned camp where a bandit is holding hostages. Defeat him and rescue them.",
-        "name": "Beat the bandit"
+        "name": "Save the Girl, Save the World"
       },
       "hone_skills": {
         "description": "There are many Zoids Sleepers in the village outskirts, perfect for honing your piloting skills.",
-        "name": "Hone your skills"
+        "name": "Field Training"
       },
       "report_to_captain": {
-        "description": "The old captain might know more about this artifact. Talk to him.",
-        "name": "Report to the captain"
+        "description": "The old captain might know more about this artifact. Talk to him in the village.",
+        "name": "Mission Report"
       },
       "captain_farewell": {
-        "description": "Now that you have reinforcements, report back to the captain before heading out.",
-        "name": "Report to the captain"
+        "description": "Now that you have reinforcements, report back to the captain in the village before heading out.",
+        "name": "Time to Depart"
       },
       "grow_army": {
         "description": "You'll need more Zoids if you plan to face the bandits. Use Jenkins' lab to incubate at least another Zoid for your army.",
-        "name": "Grow your army"
+        "name": "Recruitment"
       },
       "jenkins_to_work": {
-        "description": "You've gathered Zoid structural data. Go back to Jenkins and start working in his lab.",
-        "name": "Back to Jenkins"
+        "description": "You've gathered Zoid structural data. Head back to the village with Jenkins and start working in his lab.",
+        "name": "That's How Babies Are Made"
       },
       "obtain_zi_data": {
         "description": "Scan a Zoid Sleeper's Core to obtain structural data. Use the Core Analyzer and a Probe.",
-        "name": "Obtain Zi-Data"
+        "name": "Zoid Anatomy"
       },
       "talk_to_jenkins": {
         "description": "The captain mentioned old Jenkins, a former Zoid lab researcher. Find him and show him the Sleeper module.",
-        "name": "Talk to old Jenkins"
+        "name": "Old Jenkins"
       },
       "talk_to_boy": {
         "description": "There's a boy in the village who looks desperate. Talk to him.",
-        "name": "Talk to the boy"
+        "name": "Village in Peril"
       },
       "talk_to_hostage": {
         "description": "The bandit fled, but the hostage seems shaken. Talk to her.",
-        "name": "Talk to the hostage"
+        "name": "Hostage"
       },
       "talk_to_priest_leon": {
-        "description": "You've arrived at Wind Colony. Ask the the local priest, if he knows anything about the missing girl.",
+        "description": "You've arrived at Wind Colony. Ask the local priest if he knows anything about the missing girl.",
         "name": "Prayer to the Wind"
       },
       "talk_to_maria": {
-        "description": "Te priest mentioned a boy who keeps getting into trouble with the bandits. Talk to his sister Maria Flyheight.",
+        "description": "The priest mentioned a boy who keeps getting into trouble with the bandits. Talk to his sister Maria Flyheight.",
         "name": "The Boy from Planet Zi"
       },
       "elmia_desert_patrol": {
         "description": "Maria says her brother Van is somewhere in the Elmia Desert. Fight through the Sleepers to find him.",
-        "name": "Crossing Through Elmia"
+        "name": "Desert Ruins"
       },
       "listen_to_bandits": {
         "description": "You found some ruins in the desert. There are bandits nearby. Listen to what they're saying.",
         "name": "Voices Among Ruins"
       },
       "defeat_bul": {
-        "description": "The bandits mentioned Blu, who's trying to get rid of a boy. Help Van by holding back Blu and his Guysack.",
-        "name": "Ambush at the Ruins"
+        "description": "The bandits mentioned Blu, who's trying to get rid of a boy. Help Van by stopping Blu and his Guysack in a sortie through the Elmia Ruins.",
+        "name": "Protector"
       },
       "find_van": {
-        "description": "That will hold Blu off for a few minutes. Find Van and warn him about the incoming bandits.",
+        "description": "That will hold Blu off for a few minutes. Find Van in the ruins and warn him about the incoming bandits.",
         "name": "The Boy in the Ruins"
       },
       "defeat_bianco_nero": {
-        "description": "Blu's reinforcements have arrived. Van can't escape alone. Hold off the bandits while Van gets out.",
+        "description": "Blu's reinforcements have arrived. Van can't escape alone. Sortie into the ruins and hold off the bandits while Van gets out.",
         "name": "Wolves at the Gate"
       },
       "interrogate_bandits": {
@@ -75,8 +75,8 @@
         "name": "Truth Among Thieves"
       },
       "maria_van_status": {
-        "description": "Ask Maria how Van and the mysterious girl are doing.",
-        "name": "The Mysterious Fine"
+        "description": "Ask Maria at Wind Colony how Van and the mysterious girl are doing.",
+        "name": "What Was That About?"
       }
     },
     "name": "Sleeper Commander"

--- a/src/i18n/locales/es/campaigns.json
+++ b/src/i18n/locales/es/campaigns.json
@@ -3,44 +3,44 @@
     "description": "La Aldea Destello es atacada por Zoids Sleepers, muestra tu habilidad como piloto y descubre a los culpables.",
     "missions": {
       "beat_bandit": {
-        "description": "Encontraste un campamento abandonado donde un bandido tiene rehenes. Véncelo y rescátalos",
-        "name": "Vence al bandido"
+        "description": "Encontraste un campamento abandonado donde un bandido tiene rehenes. Véncelo y rescátalos.",
+        "name": "Salva a la chica, salva al mundo"
       },
       "hone_skills": {
         "description": "Hay muchos Zoids Sleepers en las afueras de la aldea, son perfectos para mejorar tus habilidades como piloto.",
-        "name": "Mejora tus habilidades"
+        "name": "Entrenamiento de campo"
       },
       "report_to_captain": {
-        "description": "Puede ser que el anciano capitán sepa más sobre este artefacto, habla con él",
-        "name": "Reporta al capitán"
+        "description": "Puede ser que el anciano capitán sepa más sobre este artefacto, habla con él en la aldea.",
+        "name": "Reporte de misión"
       },
       "captain_farewell": {
-        "description": "Ahora que tienes refuerzos, reporta al capitán antes de partir.",
-        "name": "Reporta al capitán"
+        "description": "Ahora que tienes refuerzos, repórtate con el capitán en la aldea antes de partir.",
+        "name": "Hora de partir"
       },
       "grow_army": {
         "description": "Necesitarás más Zoids si piensas enfrentarte a los bandidos. Usa el laboratorio de Jenkins para incubar al menos otro Zoid para tu ejército.",
-        "name": "Amplía tu ejército"
+        "name": "Reclutamiento"
       },
       "jenkins_to_work": {
-        "description": "Has conseguido datos estructurales de un Zoid. Vuelve con Jenkins y comiencen a trabajar en su laboratorio.",
-        "name": "Vuelve con Jenkins"
+        "description": "Has conseguido datos estructurales de un Zoid. Vuelve a la aldea con Jenkins y comiencen a trabajar en su laboratorio.",
+        "name": "Así se hacen los bebés"
       },
       "obtain_zi_data": {
-        "description": "Escanea el Core de un Zoid Sleeper para obtener datos estructurales. Usa el Analizador de Cores y una Sonda",
-        "name": "Obtén Zi-Data"
+        "description": "Escanea el Core de un Zoid Sleeper para obtener datos estructurales. Usa el Analizador de Cores y una Sonda.",
+        "name": "Anatomía Zoid"
       },
       "talk_to_jenkins": {
         "description": "El capitán mencionó al viejo Jenkins, un antiguo investigador de laboratorio de Zoids. Encuéntralo y muéstrale el módulo Sleeper.",
-        "name": "Habla con el viejo Jenkins"
+        "name": "El Viejo Jenkins"
       },
       "talk_to_boy": {
-        "description": "Hay un chico en la aldea que luce muy desesperado, habla con el.",
-        "name": "Habla con el chico"
+        "description": "Hay un chico en la aldea que luce muy desesperado, habla con él.",
+        "name": "Aldea en apuros"
       },
       "talk_to_hostage": {
-        "description": "El bandido huyó, peor la rehén se nota alterada, habla con ella.",
-        "name": "Habla con la rehén"
+        "description": "El bandido huyó, pero la rehén se ve alterada. Habla con ella.",
+        "name": "Rehén"
       },
       "talk_to_priest_leon": {
         "description": "Has llegado a la Colonia del Viento. Pregunta al Padre León, el sacerdote local, si sabe algo sobre la chica perdida.",
@@ -52,22 +52,22 @@
       },
       "elmia_desert_patrol": {
         "description": "María dice que su hermano Van está en algún lugar del Desierto de Elmia. Abre camino entre los Sleepers para encontrarlo.",
-        "name": "Travesía por Elmia"
+        "name": "Ruinas del Desierto"
       },
       "listen_to_bandits": {
         "description": "Encontraste unas ruinas en el desierto. Hay bandidos cerca. Escucha lo que dicen.",
         "name": "Voces entre Ruinas"
       },
       "defeat_bul": {
-        "description": "Los bandidos mencionaron a Blu, que intenta deshacerse de un niño. Ayuda a Van deteniendo a Blu y su Guysack.",
-        "name": "Emboscada en las Ruinas"
+        "description": "Los bandidos mencionaron a Blu, que intenta deshacerse de un niño. Ayuda a Van deteniendo a Blu y su Guysack incursionando en las Ruinas de Elmia.",
+        "name": "Protector"
       },
       "find_van": {
-        "description": "Eso detendrá a Blu por unos minutos. Encuentra a Van y adviértele sobre los bandidos que se acercan.",
+        "description": "Eso detendrá a Blu por unos minutos. Encuentra a Van en las ruinas y adviértele sobre los bandidos que se acercan.",
         "name": "El Chico de las Ruinas"
       },
       "defeat_bianco_nero": {
-        "description": "Los refuerzos de Blu llegaron, Van no podrá escapar solo. Detén a los bandidos mientras Van sale de ahí",
+        "description": "Los refuerzos de Blu llegaron, Van no podrá escapar solo. Incursiona en las ruinas y detén a los bandidos mientras Van sale de ahí.",
         "name": "Lobos a las Puertas"
       },
       "interrogate_bandits": {
@@ -75,8 +75,8 @@
         "name": "Verdad entre Ladrones"
       },
       "maria_van_status": {
-        "description": "Preguntale a María como se encuentra Van y la misteriosa chica.",
-        "name": "La misteriosa Fine"
+        "description": "Pregúntale a María en la Colonia del Viento cómo se encuentran Van y la misteriosa chica.",
+        "name": "¿A qué venía?"
       }
     },
     "name": "Comandante Sleeper"

--- a/src/i18n/locales/es/dialog.json
+++ b/src/i18n/locales/es/dialog.json
@@ -103,7 +103,7 @@
     "Así que sigue luchando, sigue aprendiendo y sigue piloteando. En poco tiempo serás una fuerza imparable."
   ],
   "woman": [
-    "¡Gracias por salvarme! Pero por favor, ¡tienes que ayudarme! ¡Los bandidos... se llevaron a mi hija! ¡Lo arrastraron hacia la Colonia del Viento!",
+    "¡Gracias por salvarme! Pero por favor, ¡tienes que ayudarme! ¡Los bandidos... se llevaron a mi hija! ¡La arrastraron hacia la Colonia del Viento!",
     "Estoy desesperada... es solo una niña. ¡Por favor, tienes que salvarla! La Colonia del Viento está al norte. Ten cuidado, el camino es peligroso.",
     "Toma esto, tal vez te sea útil. Esos bandidos estaban usando estos dispositivos para comandar a los Zoids alrededor de este campamento y evitar que se acerquen los soldados.",
     "Logré arrebatarle uno al que se llevó a mi hija. La verdad no se qué sea pero tal vez ese anciano de la aldea sepa qué es."


### PR DESCRIPTION
## Summary
- Fix dead enemy attacking player after victory in pilot battles, which caused both victory and defeat to trigger simultaneously — allowing the bandit fight to be skipped
- Improve campaign mission names and descriptions in both Spanish and English
- Fix typos and missing accents in localization files

## Test plan
- [x] Fight the bandit at Abandoned Camp and tap rapidly — confirm no skip occurs
- [x] Verify campaign mission names display correctly in both languages