### PR TITLE
Rebalance first bandit battle

### DIFF
--- a/src/models/Pilot.ts
+++ b/src/models/Pilot.ts
@@ -10,10 +10,10 @@ export interface Pilot {
 export const PILOTS: Record<string, Pilot> = {
   bandit1: {
     id: 'bandit1',
-    magnisReward: 200,
+    magnisReward: 3000,
     name: 'Bandit',
     zoids: [
-      { id: 'molga', level: 5 },
+      { attackOverride: 1, id: 'molga', level: 5, maxHealthOverride: 196 },
     ],
   },
   bianco_nero: {

--- a/src/models/Player.ts
+++ b/src/models/Player.ts
@@ -6,6 +6,6 @@ export interface PlayerStats {
 
 export const DEFAULT_PLAYER: PlayerStats = {
   attackMult: 1,
-  baseHealth: 0,
+  baseHealth: 10,
   clickAttack: 1,
 };

--- a/test/Pilot.test.ts
+++ b/test/Pilot.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { PILOTS } from '../src/models/Pilot';
+import { buildZoid } from '../src/models/Zoid';
+
+describe('Pilot', () => {
+  describe('bandit1', () => {
+    const bandit = PILOTS['bandit1'];
+    const molga = buildZoid(bandit.zoids[0]);
+
+    it('should have Molga with attack of 1', () => {
+      expect(molga.attack).toBe(1);
+    });
+
+    it('should have Molga with maxHealth of 196', () => {
+      expect(molga.maxHealth).toBe(196);
+    });
+
+    it('should reward 3000 magnis', () => {
+      expect(bandit.magnisReward).toBe(3000);
+    });
+  });
+});

--- a/test/Player.test.ts
+++ b/test/Player.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, it } from 'vitest';
 import { DEFAULT_PLAYER } from '../src/models/Player';
 
 describe('Player', () => {
+  it('should have default baseHealth of 10', () => {
+    expect(DEFAULT_PLAYER.baseHealth).toBe(10);
+  });
+
   it('should have default clickAttack of 1', () => {
     expect(DEFAULT_PLAYER.clickAttack).toBe(1);
   });


### PR DESCRIPTION
## Summary
- Set player base HP to 10 (was 0)
- Override bandit1 Molga attack to 1 and HP to 196 (calculated for Glidoler lvl 10, 2 clicks/sec)
- Increase bandit1 reward to 3000 magnis (enough for probe + merda)

Closes #60

## Test plan
- [x] Unit tests for bandit1 Molga stats (attack=1, HP=196)
- [x] Unit test for bandit1 reward (3000 magnis)
- [x] Unit test for player baseHealth (10)
- [x] All 165 tests passing