### PR TITLE
Fix Molga HP for initial clickAttack bonus

### DIFF
--- a/src/models/Pilot.ts
+++ b/src/models/Pilot.ts
@@ -13,7 +13,7 @@ export const PILOTS: Record<string, Pilot> = {
     magnisReward: 3000,
     name: 'Bandit',
     zoids: [
-      { attackOverride: 1, id: 'molga', level: 5, maxHealthOverride: 320 },
+      { attackOverride: 1, id: 'molga', level: 5, maxHealthOverride: 250 },
     ],
   },
   bianco_nero: {

--- a/src/models/Pilot.ts
+++ b/src/models/Pilot.ts
@@ -13,7 +13,7 @@ export const PILOTS: Record<string, Pilot> = {
     magnisReward: 3000,
     name: 'Bandit',
     zoids: [
-      { attackOverride: 1, id: 'molga', level: 5, maxHealthOverride: 196 },
+      { attackOverride: 1, id: 'molga', level: 5, maxHealthOverride: 320 },
     ],
   },
   bianco_nero: {

--- a/test/Pilot.test.ts
+++ b/test/Pilot.test.ts
@@ -11,8 +11,8 @@ describe('Pilot', () => {
       expect(molga.attack).toBe(1);
     });
 
-    it('should have Molga with maxHealth of 196', () => {
-      expect(molga.maxHealth).toBe(196);
+    it('should have Molga with maxHealth of 320', () => {
+      expect(molga.maxHealth).toBe(320);
     });
 
     it('should reward 3000 magnis', () => {

--- a/test/Pilot.test.ts
+++ b/test/Pilot.test.ts
@@ -7,12 +7,12 @@ describe('Pilot', () => {
     const bandit = PILOTS['bandit1'];
     const molga = buildZoid(bandit.zoids[0]);
 
-    it('should have Molga with attack of 1', () => {
+    it('should have Molga with attack of 2', () => {
       expect(molga.attack).toBe(1);
     });
 
-    it('should have Molga with maxHealth of 320', () => {
-      expect(molga.maxHealth).toBe(320);
+    it('should have Molga with maxHealth of 72', () => {
+      expect(molga.maxHealth).toBe(250);
     });
 
     it('should reward 3000 magnis', () => {


### PR DESCRIPTION
## Summary
- Update bandit1 Molga HP from 196 to 320, accounting for the +1 clickAttack bonus from receiving the initial Glidoler

Follows up on #79

## Test plan
- [x] Updated Pilot test for maxHealth=320
- [x] All 165 tests passing