### PR TITLE
Increase scan drop rates for early route zoids

### DIFF
--- a/src/models/Zoid.ts
+++ b/src/models/Zoid.ts
@@ -58,15 +58,15 @@ export const ZOID_LIST: Record<string, ZoidSpecies> = {
   command_wolf: { attack: 200, baseExp: 50, dropRate: 15, faction: Faction.HelicRepublic, id: 'command_wolf', levelType: LevelType.MediumFast, maxHealth: 200, name: 'Command Wolf', price: 40000 },
   elephantus: { attack: 100, baseExp: 15, dropRate: -1, faction: Faction.HelicRepublic, id: 'elephantus', levelType: LevelType.MediumSlow, maxHealth: 200, name: 'Elephantus', price: 50000 },
   garius: { attack: 50, baseExp: 10, dropRate: -1, faction: Faction.HelicRepublic, id: 'garius', levelType: LevelType.Fast, maxHealth: 100, name: 'Garius', price: 2000 },
-  gator: { attack: 150, baseExp: 35, dropRate: 25, faction: Faction.GuylosEmpire, id: 'gator', levelType: LevelType.MediumFast, maxHealth: 200, name: 'Gator', price: 4000 },
+  gator: { attack: 150, baseExp: 35, dropRate: 60, faction: Faction.GuylosEmpire, id: 'gator', levelType: LevelType.MediumFast, maxHealth: 200, name: 'Gator', price: 4000 },
   glidoler: { attack: 100, baseExp: 10, dropRate: -1, faction: Faction.HelicRepublic, id: 'glidoler', levelType: LevelType.MediumFast, maxHealth: 40, name: 'Glidoler', price: 2000 },
   guysack: { attack: 180, baseExp: 45, dropRate: 10, faction: Faction.GuylosEmpire, id: 'guysack', levelType: LevelType.MediumFast, maxHealth: 500, name: 'Guysack', price: 20000 },
-  malder: { attack: 20, baseExp: 40, dropRate: 10, faction: Faction.ZenebasEmpire, id: 'malder', levelType: LevelType.Erratic, maxHealth: 700, name: 'Malder', price: 8000 },
-  merda: { attack: 50, baseExp: 20, dropRate: 50, faction: Faction.ZenebasEmpire, id: 'merda', levelType: LevelType.Fast, maxHealth: 100, name: 'Merda', price: 2000 },
+  malder: { attack: 20, baseExp: 40, dropRate: 50, faction: Faction.ZenebasEmpire, id: 'malder', levelType: LevelType.Erratic, maxHealth: 700, name: 'Malder', price: 8000 },
+  merda: { attack: 50, baseExp: 20, dropRate: 75, faction: Faction.ZenebasEmpire, id: 'merda', levelType: LevelType.Fast, maxHealth: 100, name: 'Merda', price: 2000 },
   molga: { attack: 100, baseExp: 35, dropRate: 20, faction: Faction.ZenebasEmpire, id: 'molga', levelType: LevelType.Fast, maxHealth: 400, name: 'Molga', price: 20000 },
   shield_liger: { attack: 250, baseExp: 100, dropRate: 1, faction: Faction.HelicRepublic, id: 'shield_liger', levelType: LevelType.MediumFast, maxHealth: 600, name: 'Shield Liger', price: 100000 },
   tortoise: { attack: 100, baseExp: 30, dropRate: 20, faction: Faction.ZenebasEmpire, id: 'tortoise', levelType: LevelType.Fast, maxHealth: 700, name: 'Cannon Tortoise', price: 9000 },
-  zatton: { attack: 120, baseExp: 40, dropRate: 5, faction: Faction.ZenebasEmpire, id: 'zatton', levelType: LevelType.MediumSlow, maxHealth: 350, name: 'Zatton', price: 10000 },
+  zatton: { attack: 120, baseExp: 40, dropRate: 30, faction: Faction.ZenebasEmpire, id: 'zatton', levelType: LevelType.MediumSlow, maxHealth: 350, name: 'Zatton', price: 10000 },
 };
 
 export function calculatePartyAttack(party: OwnedZoid[]): number {

--- a/test/Scan.test.ts
+++ b/test/Scan.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { calculateScanRate } from '../src/game/Scan';
+import { ZOID_LIST } from '../src/models/Zoid';
+
+describe('calculateScanRate', () => {
+  it('should return the dropRate plus probe bonus for scannable zoids', () => {
+    expect(calculateScanRate('merda', 'core_probe')).toBe(75);
+    expect(calculateScanRate('gator', 'core_probe')).toBe(60);
+    expect(calculateScanRate('malder', 'core_probe')).toBe(50);
+    expect(calculateScanRate('zatton', 'core_probe')).toBe(30);
+  });
+
+  it('should return 0 for zoids with negative dropRate', () => {
+    const unscannable = Object.values(ZOID_LIST).filter((z) => z.dropRate < 0);
+    expect(unscannable.length).toBeGreaterThan(0);
+    unscannable.forEach((z) => {
+      expect(calculateScanRate(z.id, 'core_probe')).toBe(0);
+    });
+  });
+
+  it('should clamp scan rate to 100', () => {
+    // Merda has 75 dropRate; even with a hypothetical large bonus, rate should cap at 100
+    const rate = calculateScanRate('merda', 'core_probe');
+    expect(rate).toBeLessThanOrEqual(100);
+    expect(rate).toBeGreaterThanOrEqual(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Increase global `dropRate` for Merda (50→75), Gator (25→60), Malder (10→50), Zatton (5→30) to make scanning easier on the first 3 routes
- Add unit tests for `calculateScanRate`

Closes #62

## Test plan
- [x] All 168 tests pass
- [x] Lint passes