### PR TITLE
Add first zoid as gift (#61)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -49,7 +49,7 @@ import { Currency } from './models/Currency';
 import { getZoidImage, ZOID_LIST } from './models/Zoid';
 import { buyItem } from './store/inventoryStore';
 import { grantReward } from './reward';
-import { checkCampaigns } from './store/campaignStore';
+import { checkCampaigns, isMissionCompleted } from './store/campaignStore';
 import { addZoidToArmy, party } from './store/partyStore';
 import { addCurrency, getCurrency } from './store/walletStore';
 import { decrementZoidData } from './store/zoidDataStore';
@@ -122,9 +122,11 @@ const App: Component = () => {
           labId={activeLab()!.labId}
           onBuy={(zoidId) => {
             const zoid = ZOID_LIST[zoidId];
-            if (getCurrency(Currency.Magnis) >= zoid.price) {
+            const isFirstFree = party().length === 1 && !isMissionCompleted('sleeper_commander', 'grow_army');
+            const price = isFirstFree ? 0 : zoid.price;
+            if (getCurrency(Currency.Magnis) >= price) {
               const isNew = !party().some((z) => z.id === zoidId);
-              addCurrency(Currency.Magnis, -zoid.price);
+              addCurrency(Currency.Magnis, -price);
               decrementZoidData(zoidId);
               addZoidToArmy(zoidId);
               checkCampaigns();

--- a/src/i18n/locales/en/dialog.json
+++ b/src/i18n/locales/en/dialog.json
@@ -12,6 +12,12 @@
     "When you're fighting a Zoid Sleeper, click the probe before the battle ends. If you weaken it enough, you'll be able to scan its Core. Planning to fight several in a row? Double-click and the probe will activate automatically in every battle.",
     "Just keep in mind, probes are fragile. They break with each attempt, hit or miss. So you'll need one per scan. But hey, no complaints from me... the more you buy, the better for business!"
   ],
+  "becker_scan_gift": [
+    "Welcome! Jenkins told me you'd be stopping by. Let me explain how Core Probes work.",
+    "When you're fighting a Zoid Sleeper, click the probe before the battle ends. If you weaken it enough, you'll be able to scan its Core. Planning to fight several in a row? Double-click and the probe will activate automatically in every battle.",
+    "Just keep in mind, probes are fragile. They break with each attempt, hit or miss. So you'll need one per scan. But hey, no complaints from me... the more you buy, the better for business!",
+    "Here, take these 5 Core Probes on the house. You'll need them to scan those Sleepers out there. Good luck!"
+  ],
   "boy": [
     "Please, you have to help me! A bandit came and took my sister and my mother! They went toward the abandoned camp to the north... I'm so scared for them.",
     "But be careful, the bandit is really strong! You should take the intermediate route to get there. You'll encounter Zoids Sleepers along the way, it's good practice for your combat techniques.",
@@ -36,7 +42,8 @@
     "But then something strange happens: Zeke fuses with one of the destroyed Zoids from the ruins, and suddenly it rises, fully restored. And in a matter of seconds, Van and the Shield Liger drive the bandits away."
   ],
   "jenkins_to_work": [
-    "Well, well! So you actually managed to get a Zoid's structural data. Not bad for a rookie. Alright, time to get to work. Let's head to my humble lab and see what we can create with what you've got."
+    "Well, well! So you actually managed to get a Zoid's structural data. Not bad for a rookie. Alright, time to get to work. Let's head to my humble lab and see what we can create with what you've got.",
+    "And don't worry about the cost for the first one. Consider it a gift for your help to the village."
   ],
   "jenkins": [
     "So Malinoff sent you? Well, well... I saw how you helped the people of this village, so I'll hear you out. More Zoids, you say? The easiest way is buying them from the army, though they'll only sell you their scraps.",

--- a/src/i18n/locales/en/ui.json
+++ b/src/i18n/locales/en/ui.json
@@ -19,6 +19,7 @@
   "download_save": "Download Save",
   "fight_pilot": "Fight {{name}}",
   "fights_completed": "Zoids Fights Completed",
+  "free": "FREE",
   "interrogate_bandits": "Interrogate the bandits",
   "lab_empty": "No Zi-Data available for creation",
   "language": "Language",

--- a/src/i18n/locales/es/dialog.json
+++ b/src/i18n/locales/es/dialog.json
@@ -12,6 +12,12 @@
     "Cuando enfrentes a un Zoid Sleeper, haz clic en la sonda antes de que termine la batalla. Si logras debilitarlo lo suficiente, podrás escanear su Core. ¿Vas a pelear contra varios seguidos? Haz doble clic y la sonda se activará automáticamente en cada combate.",
     "Eso sí, las sondas son frágiles. Se rompen con cada intento, aciertes o no. Así que necesitarás una por cada escaneo. Pero por mí no hay problema... ¡mientras más compres, mejor para el negocio!"
   ],
+  "becker_scan_gift": [
+    "¡Bienvenido! Jenkins me dijo que vendrías. Déjame explicarte cómo funcionan las Sondas de Core.",
+    "Cuando enfrentes a un Zoid Sleeper, haz clic en la sonda antes de que termine la batalla. Si logras debilitarlo lo suficiente, podrás escanear su Core. ¿Vas a pelear contra varios seguidos? Haz doble clic y la sonda se activará automáticamente en cada combate.",
+    "Eso sí, las sondas son frágiles. Se rompen con cada intento, aciertes o no. Así que necesitarás una por cada escaneo. Pero por mí no hay problema... ¡mientras más compres, mejor para el negocio!",
+    "Toma, estas 5 Sondas de Core van por cuenta de la casa. Las necesitarás para escanear a esos Sleepers de ahí afuera. ¡Buena suerte!"
+  ],
   "boy": [
     "¡Por favor, tienes que ayudarme! ¡Un bandido vino y se llevó a mi hermana y a mi madre! Se fueron hacia el campamento abandonado del norte... Tengo mucho miedo por ellas.",
     "¡Pero ten cuidado, el bandido es muy fuerte! Deberías tomar la ruta intermedia para llegar. Encontrarás Zoids Sleepers por el camino, es buena práctica para tus técnicas de combate.",
@@ -44,7 +50,8 @@
     "Pero en ese momento algo extraño sucede: Zeke se fusiona con uno de los Zoids destruidos de las ruinas y de pronto este se levanta totalmente restaurado. Y en cuestión de segundos, Van y el Shield Liger ahuyentan a los bandidos."
   ],
   "jenkins_to_work": [
-    "¡Vaya, vaya! Así que lograste obtener los datos estructurales de un Zoid. Nada mal para un novato. Bien, es hora de ponernos a trabajar. Vamos a mi humilde laboratorio, veamos qué podemos crear con lo que tienes."
+    "¡Vaya, vaya! Así que lograste obtener los datos estructurales de un Zoid. Nada mal para un novato. Bien, es hora de ponernos a trabajar. Vamos a mi humilde laboratorio, veamos qué podemos crear con lo que tienes.",
+    "Y no te preocupes por el costo del primero. Considéralo un regalo por tu ayuda a la aldea."
   ],
   "priest_leon": [
     "¿Hmm, una chica perdida, dices? Me temo que no hemos escuchado nada sobre eso aquí en la Colonia del Viento. Pero... si hay alguien que sabe sobre los movimientos de los bandidos, es ese chico que siempre se mete en problemas con ellos.",

--- a/src/i18n/locales/es/ui.json
+++ b/src/i18n/locales/es/ui.json
@@ -19,6 +19,7 @@
   "download_save": "Descargar partida",
   "fight_pilot": "Luchar contra {{name}}",
   "fights_completed": "Zoids Combatidos",
+  "free": "GRATIS",
   "interrogate_bandits": "Interrogar a los bandidos",
   "lab_empty": "No hay Zi-Data disponible para crear",
   "language": "Idioma",

--- a/src/landmark/City.ts
+++ b/src/landmark/City.ts
@@ -34,6 +34,7 @@ export const CITIES: City[] = [
     actions: [
       new ActionVisitDepot([ITEMS.core_probe as ConsumableItem], [new ItemRequirement(ITEMS.core_analyzer.id)]),
       new ActionVisitLab('jenkins_lab', [new MissionCompletedRequirement('sleeper_commander', 'jenkins_to_work')]),
+      new ActionTalkToNPC('becker', [new MissionCompletedRequirement('sleeper_commander', 'talk_to_jenkins')], [new ItemRequirement(ITEMS.core_probe.id)], itemReward(ITEMS.core_probe.id, 5, false)),
       new ActionTalkToNPC('becker', [new ItemRequirement(ITEMS.core_probe.id)]),
       new ActionTalkToNPC('boy', undefined, [new MissionCompletedRequirement('sleeper_commander', 'talk_to_hostage')]),
       new ActionTalkToNPC('captain_malinoff', [new ItemRequirement(ITEMS.sleeper_module.id)], [new MissionCompletedRequirement('sleeper_commander', 'talk_to_jenkins')]),

--- a/src/npc/Npc.ts
+++ b/src/npc/Npc.ts
@@ -1,4 +1,5 @@
-import { MissionCompletedRequirement } from '../requirement';
+import { ITEMS } from '../item';
+import { ItemRequirement, MissionCompletedRequirement } from '../requirement';
 import type { Requirement } from '../requirement';
 
 export interface NpcDialog {
@@ -15,7 +16,10 @@ export interface Npc {
 
 export const NPCS: Record<string, Npc> = {
   becker: {
-    dialogs: [{ dialogKey: 'dialog:becker_scan' }],
+    dialogs: [
+      { dialogKey: 'dialog:becker_scan', unlockRequirement: new ItemRequirement(ITEMS.core_probe.id) },
+      { dialogKey: 'dialog:becker_scan_gift' },
+    ],
     id: 'becker',
     nameKey: 'pilots:becker',
   },

--- a/src/ui/LabPanel.tsx
+++ b/src/ui/LabPanel.tsx
@@ -3,6 +3,8 @@ import { t } from '../i18n';
 import { FACTIONS } from '../models/Faction';
 import { Currency } from '../models/Currency';
 import { getZoidImage, ZOID_LIST } from '../models/Zoid';
+import { isMissionCompleted } from '../store/campaignStore';
+import { party } from '../store/partyStore';
 import { getZoidDataCount } from '../store/zoidDataStore';
 import { getCurrency } from '../store/walletStore';
 
@@ -40,7 +42,8 @@ const LabPanel: Component<LabPanelProps> = (props) => {
           <div class="archive-grid">
             <For each={availableZoids()}>
               {(entry) => {
-                const canAfford = () => getCurrency(Currency.Magnis) >= entry.data.price;
+                const isFirstFree = () => party().length === 1 && !isMissionCompleted('sleeper_commander', 'grow_army');
+                const canAfford = () => isFirstFree() || getCurrency(Currency.Magnis) >= entry.data.price;
                 return (
                   <button
                     class={`archive-card lab-card ${canAfford() ? '' : 'lab-card--disabled'}`}
@@ -54,10 +57,16 @@ const LabPanel: Component<LabPanelProps> = (props) => {
                       alt={entry.data.name}
                     />
                     <span class="archive-card-name">{entry.data.name}</span>
-                    <div class="lab-card-price">
-                      <img class="shop-price-icon" src="images/items/magnis.png" alt="" />
-                      <span>{entry.data.price.toLocaleString()}</span>
-                    </div>
+                    <Show when={isFirstFree()} fallback={
+                      <div class="lab-card-price">
+                        <img class="shop-price-icon" src="images/items/magnis.png" alt="" />
+                        <span>{entry.data.price.toLocaleString()}</span>
+                      </div>
+                    }>
+                      <div class="lab-card-price">
+                        <span>{t('ui:free')}</span>
+                      </div>
+                    </Show>
                     <span class="lab-card-zdata">Z-Data: {getZoidDataCount(entry.id)}</span>
                   </button>
                 );


### PR DESCRIPTION
## Summary
- Ms Becker grants 5 core probes the first time you talk to her (gift dialog with tips)
- Jenkins tells the player the first zoid is on him for helping the village
- First zoid in the lab is free (shows FREE tag instead of price)
- Free zoid guard: party size === 1 and `grow_army` mission not completed

## Known limitation
If the player uses all core probes and talks to Becker again, the gift dialog replays. Will be fixed with requirement operators.

Closes #61

## Test plan
- [x] Progress to `jenkins_to_work`, talk to Becker → grants 5 core probes
- [x] Open lab → first zoid shows FREE tag and is purchasable without Magnis
- [x] After buying, subsequent zoids show normal prices
- [x] `npm test` passes