### PR TITLE
Add operator requirements (#39)

### DIFF
--- a/src/i18n/locales/en/requirements.json
+++ b/src/i18n/locales/en/requirements.json
@@ -1,11 +1,14 @@
 {
+  "all_of_joiner": " and ",
   "army_size_required": "Have at least {{count}} zoids in army",
+  "at_least_one_joiner": " or ",
   "complete_campaign": "Complete campaign: {{name}}",
   "complete_mission": "Complete mission: {{mission}} of the operation {{campaign}}",
   "defeat_pilot": "Defeat {{name}}",
   "item_required": "Have {{count}} {{item}}",
   "defeat_zoids_on_route": "Defeat {{count}} zoids on {{route}}",
   "magnis_required": "Have {{count}} Magnis",
+  "only_one": "Only one of: {{hints}}",
   "talk_to_npc": "Talk to {{name}}",
   "zi_data_required": "Have at least {{count}} Zi-Data"
 }

--- a/src/i18n/locales/es/requirements.json
+++ b/src/i18n/locales/es/requirements.json
@@ -1,11 +1,14 @@
 {
+  "all_of_joiner": " y ",
   "army_size_required": "Tener al menos {{count}} Zoids en el ejército",
+  "at_least_one_joiner": " o ",
   "complete_campaign": "Completar operación: {{name}}",
   "complete_mission": "Completar misión: {{mission}} de la operación {{campaign}}",
   "defeat_pilot": "Derrota a {{name}}",
   "item_required": "Tener {{count}} {{item}}",
   "defeat_zoids_on_route": "Derrota {{count}} zoids en {{route}}",
   "magnis_required": "Tener {{count}} Magnis",
+  "only_one": "Solo uno de: {{hints}}",
   "talk_to_npc": "Hablar con {{name}}",
   "zi_data_required": "Tener al menos {{count}} Zi-Data"
 }

--- a/src/landmark/City.ts
+++ b/src/landmark/City.ts
@@ -1,6 +1,6 @@
 import { type ConsumableItem, ITEMS } from '../item';
 import { PILOTS } from '../models/Pilot';
-import { ItemRequirement, MissionCompletedRequirement, PilotDefeatRequirement, RouteKillRequirement } from '../requirement';
+import { COMPOUND_REQUIREMENTS, ItemRequirement, MissionCompletedRequirement, PilotDefeatRequirement, RouteKillRequirement } from '../requirement';
 import { itemReward } from '../reward';
 import { ActionFightPilot } from './action/ActionFightPilot';
 import { ActionTalkToNPC } from './action/ActionTalkToNPC';
@@ -34,8 +34,8 @@ export const CITIES: City[] = [
     actions: [
       new ActionVisitDepot([ITEMS.core_probe as ConsumableItem], [new ItemRequirement(ITEMS.core_analyzer.id)]),
       new ActionVisitLab('jenkins_lab', [new MissionCompletedRequirement('sleeper_commander', 'jenkins_to_work')]),
-      new ActionTalkToNPC('becker', [new MissionCompletedRequirement('sleeper_commander', 'talk_to_jenkins')], [new ItemRequirement(ITEMS.core_probe.id)], itemReward(ITEMS.core_probe.id, 5, false)),
-      new ActionTalkToNPC('becker', [new ItemRequirement(ITEMS.core_probe.id)]),
+      new ActionTalkToNPC('becker', [new MissionCompletedRequirement('sleeper_commander', 'talk_to_jenkins')], [COMPOUND_REQUIREMENTS.becker_probes], itemReward(ITEMS.core_probe.id, 5, false)),
+      new ActionTalkToNPC('becker', [COMPOUND_REQUIREMENTS.becker_probes]),
       new ActionTalkToNPC('boy', undefined, [new MissionCompletedRequirement('sleeper_commander', 'talk_to_hostage')]),
       new ActionTalkToNPC('captain_malinoff', [new ItemRequirement(ITEMS.sleeper_module.id)], [new MissionCompletedRequirement('sleeper_commander', 'talk_to_jenkins')]),
       new ActionTalkToNPC('captain_malinoff', [new MissionCompletedRequirement('sleeper_commander', 'grow_army')]),

--- a/src/npc/Npc.ts
+++ b/src/npc/Npc.ts
@@ -1,5 +1,4 @@
-import { ITEMS } from '../item';
-import { ItemRequirement, MissionCompletedRequirement } from '../requirement';
+import { COMPOUND_REQUIREMENTS, MissionCompletedRequirement } from '../requirement';
 import type { Requirement } from '../requirement';
 
 export interface NpcDialog {
@@ -17,7 +16,7 @@ export interface Npc {
 export const NPCS: Record<string, Npc> = {
   becker: {
     dialogs: [
-      { dialogKey: 'dialog:becker_scan', unlockRequirement: new ItemRequirement(ITEMS.core_probe.id) },
+      { dialogKey: 'dialog:becker_scan', unlockRequirement: COMPOUND_REQUIREMENTS.becker_probes },
       { dialogKey: 'dialog:becker_scan_gift' },
     ],
     id: 'becker',

--- a/src/requirement/AllOfRequirement.ts
+++ b/src/requirement/AllOfRequirement.ts
@@ -1,0 +1,24 @@
+import { t } from '../i18n';
+import type { Requirement } from './Requirement';
+
+export class AllOfRequirement implements Requirement {
+  requirements: Requirement[];
+  requiredValue: number;
+
+  constructor(requirements: Requirement[]) {
+    this.requirements = requirements;
+    this.requiredValue = requirements.length;
+  }
+
+  hint(): string {
+    return this.requirements.map((r) => r.hint()).join(t('requirements:all_of_joiner'));
+  }
+
+  isCompleted(): boolean {
+    return this.requirements.every((r) => r.isCompleted());
+  }
+
+  progress(): number {
+    return this.requirements.filter((r) => r.isCompleted()).length;
+  }
+}

--- a/src/requirement/AtLeastOneRequirement.ts
+++ b/src/requirement/AtLeastOneRequirement.ts
@@ -1,0 +1,23 @@
+import { t } from '../i18n';
+import type { Requirement } from './Requirement';
+
+export class AtLeastOneRequirement implements Requirement {
+  requirements: Requirement[];
+  requiredValue = 1;
+
+  constructor(requirements: Requirement[]) {
+    this.requirements = requirements;
+  }
+
+  hint(): string {
+    return this.requirements.map((r) => r.hint()).join(t('requirements:at_least_one_joiner'));
+  }
+
+  isCompleted(): boolean {
+    return this.requirements.some((r) => r.isCompleted());
+  }
+
+  progress(): number {
+    return this.requirements.some((r) => r.isCompleted()) ? 1 : 0;
+  }
+}

--- a/src/requirement/CompoundRequirements.ts
+++ b/src/requirement/CompoundRequirements.ts
@@ -1,0 +1,13 @@
+import { ITEMS } from '../item';
+import { AtLeastOneRequirement } from './AtLeastOneRequirement';
+import { ItemRequirement } from './ItemRequirement';
+import { MissionCompletedRequirement } from './MissionCompletedRequirement';
+import { NpcTalkedInCampaignRequirement } from './NpcTalkedInCampaignRequirement';
+
+export const COMPOUND_REQUIREMENTS = {
+  becker_probes: new AtLeastOneRequirement([
+    new ItemRequirement(ITEMS.core_probe.id),
+    new MissionCompletedRequirement('sleeper_commander', 'obtain_zi_data'),
+    new NpcTalkedInCampaignRequirement('sleeper_commander', 'becker'),
+  ]),
+} as const;

--- a/src/requirement/OnlyOneRequirement.ts
+++ b/src/requirement/OnlyOneRequirement.ts
@@ -1,0 +1,24 @@
+import { t } from '../i18n';
+import type { Requirement } from './Requirement';
+
+export class OnlyOneRequirement implements Requirement {
+  requirements: Requirement[];
+  requiredValue = 1;
+
+  constructor(requirements: Requirement[]) {
+    this.requirements = requirements;
+  }
+
+  hint(): string {
+    const hints = this.requirements.map((r) => r.hint()).join(t('requirements:at_least_one_joiner'));
+    return t('requirements:only_one', { hints });
+  }
+
+  isCompleted(): boolean {
+    return this.requirements.filter((r) => r.isCompleted()).length === 1;
+  }
+
+  progress(): number {
+    return this.requirements.filter((r) => r.isCompleted()).length === 1 ? 1 : 0;
+  }
+}

--- a/src/requirement/index.ts
+++ b/src/requirement/index.ts
@@ -1,10 +1,14 @@
+export { AllOfRequirement } from './AllOfRequirement';
 export { ArmySizeRequirement } from './ArmySizeRequirement';
+export { AtLeastOneRequirement } from './AtLeastOneRequirement';
 export { CampaignCompletedRequirement } from './CampaignCompletedRequirement';
 export { ComparisonCondition, evaluateCondition } from './ComparisonCondition';
+export { COMPOUND_REQUIREMENTS } from './CompoundRequirements';
 export { ItemRequirement } from './ItemRequirement';
 export { MagnisRequirement } from './MagnisRequirement';
 export { MissionCompletedRequirement } from './MissionCompletedRequirement';
 export { NpcTalkedInCampaignRequirement } from './NpcTalkedInCampaignRequirement';
+export { OnlyOneRequirement } from './OnlyOneRequirement';
 export { PilotDefeatRequirement } from './PilotDefeatRequirement';
 export type { Requirement } from './Requirement';
 export { RouteKillRequirement } from './RouteKillRequirement';

--- a/test/OperatorRequirement.test.ts
+++ b/test/OperatorRequirement.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import { AllOfRequirement, AtLeastOneRequirement, OnlyOneRequirement } from '../src/requirement';
+import type { Requirement } from '../src/requirement';
+
+function fakeRequirement(completed: boolean): Requirement {
+  return {
+    hint: () => (completed ? 'done' : 'pending'),
+    isCompleted: () => completed,
+    progress: () => (completed ? 1 : 0),
+    requiredValue: 1,
+  };
+}
+
+describe('AllOfRequirement', () => {
+  it('should be completed when all sub-requirements are completed', () => {
+    const req = new AllOfRequirement([fakeRequirement(true), fakeRequirement(true)]);
+
+    expect(req.isCompleted()).toBe(true);
+  });
+
+  it('should not be completed when any sub-requirement is incomplete', () => {
+    const req = new AllOfRequirement([fakeRequirement(true), fakeRequirement(false)]);
+
+    expect(req.isCompleted()).toBe(false);
+  });
+
+  it('should return count of completed sub-requirements as progress', () => {
+    const req = new AllOfRequirement([fakeRequirement(true), fakeRequirement(false), fakeRequirement(true)]);
+
+    expect(req.progress()).toBe(2);
+    expect(req.requiredValue).toBe(3);
+  });
+
+  it('should join hints with and', () => {
+    const req = new AllOfRequirement([fakeRequirement(true), fakeRequirement(false)]);
+
+    expect(req.hint()).toBe('done and pending');
+  });
+});
+
+describe('AtLeastOneRequirement', () => {
+  it('should be completed when at least one sub-requirement is completed', () => {
+    const req = new AtLeastOneRequirement([fakeRequirement(false), fakeRequirement(true)]);
+
+    expect(req.isCompleted()).toBe(true);
+  });
+
+  it('should not be completed when no sub-requirements are completed', () => {
+    const req = new AtLeastOneRequirement([fakeRequirement(false), fakeRequirement(false)]);
+
+    expect(req.isCompleted()).toBe(false);
+  });
+
+  it('should return 1 as progress when any sub-requirement is completed', () => {
+    const req = new AtLeastOneRequirement([fakeRequirement(false), fakeRequirement(true)]);
+
+    expect(req.progress()).toBe(1);
+    expect(req.requiredValue).toBe(1);
+  });
+
+  it('should return 0 as progress when none are completed', () => {
+    const req = new AtLeastOneRequirement([fakeRequirement(false), fakeRequirement(false)]);
+
+    expect(req.progress()).toBe(0);
+  });
+
+  it('should join hints with or', () => {
+    const req = new AtLeastOneRequirement([fakeRequirement(true), fakeRequirement(false)]);
+
+    expect(req.hint()).toBe('done or pending');
+  });
+});
+
+describe('OnlyOneRequirement', () => {
+  it('should be completed when exactly one sub-requirement is completed', () => {
+    const req = new OnlyOneRequirement([fakeRequirement(false), fakeRequirement(true), fakeRequirement(false)]);
+
+    expect(req.isCompleted()).toBe(true);
+  });
+
+  it('should not be completed when no sub-requirements are completed', () => {
+    const req = new OnlyOneRequirement([fakeRequirement(false), fakeRequirement(false)]);
+
+    expect(req.isCompleted()).toBe(false);
+  });
+
+  it('should not be completed when more than one sub-requirement is completed', () => {
+    const req = new OnlyOneRequirement([fakeRequirement(true), fakeRequirement(true)]);
+
+    expect(req.isCompleted()).toBe(false);
+  });
+
+  it('should return 1 as progress only when exactly one is completed', () => {
+    const one = new OnlyOneRequirement([fakeRequirement(true), fakeRequirement(false)]);
+    const two = new OnlyOneRequirement([fakeRequirement(true), fakeRequirement(true)]);
+
+    expect(one.progress()).toBe(1);
+    expect(two.progress()).toBe(0);
+  });
+
+  it('should show hint with only one prefix', () => {
+    const req = new OnlyOneRequirement([fakeRequirement(true), fakeRequirement(false)]);
+
+    expect(req.hint()).toBe('Only one of: done or pending');
+  });
+});


### PR DESCRIPTION
## Summary
- Add composite requirement classes: `AllOfRequirement`, `AtLeastOneRequirement`, `OnlyOneRequirement`
- Add `COMPOUND_REQUIREMENTS` catalog for reusable predefined compound requirements
- Apply `becker_probes` compound requirement to Ms Becker's NPC dialog and city actions
- Add i18n translations (EN/ES) for operator joiners
- Add unit tests for all three operator requirements

## Test plan
- [x] All 182 tests pass (27 files)
- [x] ESLint + TypeScript checks pass via lint-staged

Closes #39