### PR TITLE
Replace core probes with core preservers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zoids-sleeper",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zoids-sleeper",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "i18next": "^26.0.3",
         "solid-js": "^1.9.11"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zoids-sleeper",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/game/migrations.ts
+++ b/src/game/migrations.ts
@@ -6,6 +6,12 @@ export type MigrationData = Partial<SaveData> & Record<string, unknown>;
 type MigrationFn = (data: MigrationData) => void;
 
 const migrations: Record<string, MigrationFn> = {
+  '0.2.1': (data) => {
+    const inv = data.inventory as Record<string, number> | undefined;
+    if (!inv?.['core_probe']) {return;}
+    inv['core_preserver'] = (inv['core_preserver'] ?? 0) + inv['core_probe'];
+    delete inv['core_probe'];
+  },
   '0.2.0': (data) => {
     const campaign = data.campaigns?.['sleeper_commander'];
     if (!campaign) {return;}

--- a/src/i18n/locales/en/dialog.json
+++ b/src/i18n/locales/en/dialog.json
@@ -8,15 +8,15 @@
     "Problem is, he keeps stumbling into our operations. Blu tried to chase him off with his Guysack, but the brat won't take a hint. Let's head to the ruins and help Bulu get rid of that nuisance once and for all."
   ],
   "becker_scan": [
-    "Oh, a customer! People rarely buy Core Probes from me, so let me give you a tip to get the most out of them.",
-    "When you're fighting a Zoid Sleeper, click the probe before the battle ends. If you weaken it enough, you'll be able to scan its Core. Planning to fight several in a row? Double-click and the probe will activate automatically in every battle.",
-    "Just keep in mind, probes are fragile. They break with each attempt, hit or miss. So you'll need one per scan. But hey, no complaints from me... the more you buy, the better for business!"
+    "Oh, a customer! People rarely buy Core Preservers from me, so let me give you a tip to get the most out of them.",
+    "When you're fighting a Zoid Sleeper, activate the preserver before the battle ends. If you weaken it enough, the preserver will try to extract and preserve its Core. Planning to fight several in a row? Double-click and the preserver will activate automatically in every battle.",
+    "Just keep in mind, each preserver must be sterile to avoid damaging the Core, so they can only be used once. You'll need one per extraction. But hey, no complaints from me... the more you buy, the better for business!"
   ],
   "becker_scan_gift": [
-    "Welcome! Jenkins told me you'd be stopping by. Let me explain how Core Probes work.",
-    "When you're fighting a Zoid Sleeper, click the probe before the battle ends. If you weaken it enough, you'll be able to scan its Core. Planning to fight several in a row? Double-click and the probe will activate automatically in every battle.",
-    "Just keep in mind, probes are fragile. They break with each attempt, hit or miss. So you'll need one per scan. But hey, no complaints from me... the more you buy, the better for business!",
-    "Here, take these 5 Core Probes on the house. You'll need them to scan those Sleepers out there. Good luck!"
+    "Welcome! Jenkins told me you'd be stopping by. Let me explain how Core Preservers work.",
+    "When you're fighting a Zoid Sleeper, activate the preserver before the battle ends. If you weaken it enough, the preserver will try to extract and preserve its Core. Planning to fight several in a row? Double-click and the preserver will activate automatically in every battle.",
+    "Just keep in mind, each preserver must be sterile to avoid damaging the Core, so they can only be used once. You'll need one per extraction. But hey, no complaints from me... the more you buy, the better for business!",
+    "Here, take these 5 Core Preservers on the house. You'll need them to extract the Cores of those Sleepers out there. Good luck!"
   ],
   "boy": [
     "Please, you have to help me! A bandit came and took my sister and my mother! They went toward the abandoned camp to the north... I'm so scared for them.",
@@ -49,9 +49,9 @@
     "So Malinoff sent you? Well, well... I saw how you helped the people of this village, so I'll hear you out. More Zoids, you say? The easiest way is buying them from the army, though they'll only sell you their scraps.",
     "I stopped working with Zoids a long time ago, but back in my day we used traps to catch wild Zoids. Nowadays it's nearly impossible to find them, let alone get one to cooperate with you. So the armies came up with a new method: we learned to incubate Zoid Cores.",
     "As you know, the Zoid Core is the vital nucleus of every Zoid. Each species has a different Core, but they all share the same origin: the metals dissolved in the planet's primordial waters. What we managed to do was recreate the conditions of those ancient waters in a laboratory. If you gather enough Zoid Magnite, or failing that, plenty of Magnis, we can submerge it in that substance and create a brand new Zoid Core.",
-    "The next step is shaping that Core into the species you need. For that, you'll need the Zoid's structural data. Here, take this. It's a Core Analyzer. Connect it to an active Zoid Core and you can scan its structure to get the data we need to shape a new Core after that species.",
-    "There are a lot of Zoid Sleepers roaming this region lately. If you come across one, try not to wreck it and analyze its Core instead. Fair warning though, no Zoid will just let you access its Core. You'll have to immobilize it first. I won't lie to you, taking down a Zoid without destroying it is no easy feat.",
-    "Once you've got the data from a Zoid, come see me and we'll start incubating some Cores. With this basic lab, we can only hatch simple Zoids, and I can't promise a high success rate. One last thing: to connect the Analyzer to the Cores you'll need a Probe. They're single-use, so you'll have to stock up. Visit Mrs. Becker's workshop, she should have them."
+    "The next step is shaping that Core into the species you need. For that, you'll need the Zoid's structural data. Here, take this. It's a Core Analyzer. With it, you can analyze the data from a preserved Zoid Core and get the blueprint we need to shape a new one after that species.",
+    "There are a lot of Zoid Sleepers roaming this region lately. If you come across one, try to weaken it and preserve its Core before it's destroyed. Fair warning though, no Zoid will just let you access its Core. You'll have to immobilize it first. I won't lie to you, taking down a Zoid without destroying it is no easy feat.",
+    "Once you've got the data from a Zoid's core, come see me and we can clone it in the lab. With this basic lab, we can only hatch simple Zoids, and I can't promise a high success rate. One last thing: to extract and preserve the Cores you'll need a Core Preserver. They're single-use, so you'll have to stock up. Visit Mrs. Becker's workshop, she should have them."
   ],
   "priest_leon": [
     "Hmm, a missing girl, you say? I'm afraid we haven't heard anything about that here in Wind Colony. But... if anyone would know about the bandits' movements, it's that boy who's always getting himself into trouble with them.",
@@ -64,7 +64,7 @@
   ],
   "explorer_dungeon_tips": [
     "You're heading into the ruins? I've been down there a few times myself. Let me tell you what to expect.",
-    "If you manage to immobilize a Zoid to scan its Zi-Data, take the chance to collect some Zi metal too. You'll need it to prepare your Zoids for sorties into the ruins.",
+    "If you manage to weaken a Zoid enough to preserve its Core, take the chance to collect some Zi metal too. You'll need it to prepare your Zoids for sorties into the ruins.",
     "Once inside, you'll run into hostile Sleepers near the entrance. But the deeper you go, the more dangerous they become. Some are far more dangerous than the rest, but they usually guard more valuable treasures.",
     "The ruins are full of surprises. Strange things happen down there... you'll have to make choices that could help you or make things worse. And if you're lucky, you might stumble upon some supplies along the way.",
     "Whatever you're looking for, don't go in unless you're ready for a real fight."

--- a/src/i18n/locales/en/items.json
+++ b/src/i18n/locales/en/items.json
@@ -7,6 +7,10 @@
     "description": "A device that can be used to obtain structural data from Zoid Cores.",
     "name": "Core Analyzer"
   },
+  "core_preserver": {
+    "description": "A device to preserve the Core of a weakened Zoid in order to extract structural data.",
+    "name": "Core Preserver"
+  },
   "core_probe": {
     "description": "A probe to connect to the Zoid Core. Can obtain structural data.",
     "name": "Core Probe"

--- a/src/i18n/locales/es/dialog.json
+++ b/src/i18n/locales/es/dialog.json
@@ -8,15 +8,15 @@
     "Blu ha estado lidiando solo con eso, pero ni con su Guysack logra espantar al mocoso. Vamos a las ruinas a ayudar a Blu a deshacerse de esa plaga de una vez por todas."
   ],
   "becker_scan": [
-    "¡Oh, un cliente! Rara vez me compran Sondas de Core, así que déjame darte un consejo para que les saques provecho.",
-    "Cuando enfrentes a un Zoid Sleeper, haz clic en la sonda antes de que termine la batalla. Si logras debilitarlo lo suficiente, podrás escanear su Core. ¿Vas a pelear contra varios seguidos? Haz doble clic y la sonda se activará automáticamente en cada combate.",
-    "Eso sí, las sondas son frágiles. Se rompen con cada intento, aciertes o no. Así que necesitarás una por cada escaneo. Pero por mí no hay problema... ¡mientras más compres, mejor para el negocio!"
+    "¡Oh, un cliente! Rara vez me compran Preservadores de Core, así que déjame darte un consejo para que les saques provecho.",
+    "Cuando enfrentes a un Zoid Sleeper, activa el preservador antes de que termine la batalla. Si logras debilitarlo lo suficiente, el preservador intentará extraer y preservar su Core. ¿Vas a pelear contra varios seguidos? Haz doble clic y el preservador se activará automáticamente en cada combate.",
+    "Eso sí, cada preservador debe estar estéril para no dañar el Core, así que solo se pueden usar una vez. Necesitarás uno por cada extracción. Pero por mí no hay problema... ¡mientras más compres, mejor para el negocio!"
   ],
   "becker_scan_gift": [
-    "¡Bienvenido! Jenkins me dijo que vendrías. Déjame explicarte cómo funcionan las Sondas de Core.",
-    "Cuando enfrentes a un Zoid Sleeper, haz clic en la sonda antes de que termine la batalla. Si logras debilitarlo lo suficiente, podrás escanear su Core. ¿Vas a pelear contra varios seguidos? Haz doble clic y la sonda se activará automáticamente en cada combate.",
-    "Eso sí, las sondas son frágiles. Se rompen con cada intento, aciertes o no. Así que necesitarás una por cada escaneo. Pero por mí no hay problema... ¡mientras más compres, mejor para el negocio!",
-    "Toma, estas 5 Sondas de Core van por cuenta de la casa. Las necesitarás para escanear a esos Sleepers de ahí afuera. ¡Buena suerte!"
+    "¡Bienvenido! Jenkins me dijo que vendrías. Déjame explicarte cómo funcionan los Preservadores de Core.",
+    "Cuando enfrentes a un Zoid Sleeper, activa el preservador antes de que termine la batalla. Si logras debilitarlo lo suficiente, el preservador intentará extraer y preservar su Core. ¿Vas a pelear contra varios seguidos? Haz doble clic y el preservador se activará automáticamente en cada combate.",
+    "Eso sí, cada preservador debe estar estéril para no dañar el Core, así que solo se pueden usar una vez. Necesitarás uno por cada extracción. Pero por mí no hay problema... ¡mientras más compres, mejor para el negocio!",
+    "Toma, estos 5 Preservadores de Core van por cuenta de la casa. Los necesitarás para extraer los Cores de esos Sleepers de ahí afuera. ¡Buena suerte!"
   ],
   "boy": [
     "¡Por favor, tienes que ayudarme! ¡Un bandido vino y se llevó a mi hermana y a mi madre! Se fueron hacia el campamento abandonado del norte... Tengo mucho miedo por ellas.",
@@ -27,9 +27,9 @@
     "¿Así que Malinoff te envía? Vaya, vaya... Vi cómo ayudaste a la gente de esta aldea, así que por eso acepto hablar contigo. ¿Conseguir más Zoids? La forma más fácil es comprárselos al ejército, aunque solo te darán sus desechos.",
     "Yo dejé de trabajar con Zoids hace mucho, pero en mis tiempos usábamos trampas para capturar Zoids salvajes. Hoy en día es casi imposible encontrarlos, y más aún lograr que cooperen contigo. Así que los ejércitos idearon una nueva forma: aprendimos a incubar Zoid Cores.",
     "Como sabes, el Zoid Core es el núcleo vital de cada Zoid. Cada especie tiene un Core distinto, pero todos comparten un mismo origen: los metales disueltos en las aguas primigenias del planeta. Lo que logramos fue recrear las condiciones de esas aguas primitivas en un laboratorio. Si consigues suficiente Zoid Magnite, o en su defecto bastante Magnis, podemos sumergirlo en esa sustancia y crear un Zoid Core nuevo.",
-    "El siguiente paso es moldear ese Core a la especie que necesites. Para eso hacen falta datos estructurales del Zoid. Toma, esto es un Analizador de Cores. Si lo conectas a un Zoid Core activo, puedes escanear su estructura y obtener los datos que necesitamos para moldear un Core nuevo según esa especie.",
-    "Últimamente hay muchos Zoid Sleepers por esta región. Si te topas con uno, intenta no destrozarlo y analiza su Core. Eso sí, ningún Zoid te dará acceso a su Core así como así. Tendrás que inmovilizarlo primero. No te voy a mentir, inmovilizar un Zoid sin destruirlo no es tarea fácil.",
-    "Si consigues los datos de un Zoid, ven a verme y pondremos a incubar algunos Cores. Aunque con este laboratorio tan básico solo podremos crear Zoids simples, y no te garantizo mucho éxito. Solo te falta una pieza importante: para conectar el Analizador a los Cores necesitarás una Sonda. Son de un solo uso, así que tendrás que invertir en ellas. Visita el taller de la señora Becker, seguro las tiene."
+    "El siguiente paso es moldear ese Core a la especie que necesites. Para eso hacen falta datos estructurales del Zoid. Toma, esto es un Analizador de Cores. Con él, puedes analizar los datos de un Zoid Core preservado y obtener el plano que necesitamos para moldear un Core nuevo según esa especie.",
+    "Últimamente hay muchos Zoid Sleepers por esta región. Si te topas con uno, intenta debilitarlo y preservar su Core antes de que se destruya. Eso sí, ningún Zoid te dará acceso a su Core así como así. Tendrás que inmovilizarlo primero. No te voy a mentir, inmovilizar un Zoid sin destruirlo no es tarea fácil.",
+    "Si consigues los datos del core de un Zoid, ven a verme y podremos clonarlo en el laboratorio. Aunque con este laboratorio tan básico solo podremos crear Zoids simples, y no te garantizo mucho éxito. Solo te falta una pieza importante: para extraer y preservar los Cores necesitarás un Preservador de Core. Son de un solo uso, así que tendrás que invertir en ellos. Visita el taller de la señora Becker, seguro los tiene."
   ],
   "maria_fiona": [
     "¿Así que estabas preocupado por Van? Él se fue temprano con esa chica y ese dinosaurio que encontraron. Creo que le está enseñando la ciudad. Ese chico... siempre metiéndose en estas situaciones.",
@@ -59,7 +59,7 @@
   ],
   "explorer_dungeon_tips": [
     "¿Vas a entrar a las ruinas? Yo ya he bajado un par de veces. Déjame contarte qué esperar.",
-    "Si logras inmovilizar a un Zoid para escanear su Zi-Data, aprovecha para recoger un poco de Metal Zi. Lo vas a necesitar para preparar a tus Zoids para las incursiones en las ruinas.",
+    "Si logras debilitar a un Zoid lo suficiente como para preservar su Core, aprovecha para recoger un poco de Metal Zi. Lo vas a necesitar para preparar a tus Zoids para las incursiones en las ruinas.",
     "Una vez adentro, te toparás con Sleepers hostiles cerca de la entrada. Pero conforme vayas avanzando se volverán más peligrosos. Algunos son mucho más peligrosos que el resto, pero generalmente custodian tesoros más valiosos.",
     "Las ruinas están llenas de sorpresas. Cosas extrañas pasan ahí abajo... tendrás que tomar decisiones que podrían ayudarte o empeorarte las cosas. Y si tienes suerte, podrías encontrar algunos suministros en el camino.",
     "Sea lo que sea que busques, no entres a menos que estés listo para una pelea de verdad."

--- a/src/i18n/locales/es/items.json
+++ b/src/i18n/locales/es/items.json
@@ -7,6 +7,10 @@
     "description": "Un dispositivo usado para obtener información estructural de los Zoid Cores",
     "name": "Analizador de Cores"
   },
+  "core_preserver": {
+    "description": "Un dispositivo para preservar el Core de un Zoid debilitado y poder extraer datos estructurales.",
+    "name": "Preservador de Core"
+  },
   "core_probe": {
     "description": "Una sonda para conectarse al Zoid Core. Puede obtener datos estructurales.",
     "name": "Sonda de Core"

--- a/src/item/items.ts
+++ b/src/item/items.ts
@@ -5,6 +5,7 @@ import { SyncDeviceItem } from './SyncDeviceItem';
 export const ITEMS: Record<string, ItemDefinition> = {
   ancient_statue: new ImportantItem('ancient_statue'),
   core_analyzer: new ImportantItem('core_analyzer'),
+  core_preserver: new SyncDeviceItem('core_preserver', 100, 0),
   core_probe: new SyncDeviceItem('core_probe', 100, 0),
   sleeper_module: new ImportantItem('sleeper_module'),
 };

--- a/src/landmark/City.ts
+++ b/src/landmark/City.ts
@@ -32,9 +32,9 @@ export const CITIES: City[] = [
   },
   {
     actions: [
-      new ActionVisitDepot([ITEMS.core_probe as ConsumableItem], [new ItemRequirement(ITEMS.core_analyzer.id)]),
+      new ActionVisitDepot([ITEMS.core_preserver as ConsumableItem], [new ItemRequirement(ITEMS.core_analyzer.id)]),
       new ActionVisitLab('jenkins_lab', [new MissionCompletedRequirement('sleeper_commander', 'jenkins_to_work')]),
-      new ActionTalkToNPC('becker', [new MissionCompletedRequirement('sleeper_commander', 'talk_to_jenkins')], [COMPOUND_REQUIREMENTS.becker_probes], itemReward(ITEMS.core_probe.id, 5, false)),
+      new ActionTalkToNPC('becker', [new MissionCompletedRequirement('sleeper_commander', 'talk_to_jenkins')], [COMPOUND_REQUIREMENTS.becker_probes], itemReward(ITEMS.core_preserver.id, 5, false)),
       new ActionTalkToNPC('becker', [COMPOUND_REQUIREMENTS.becker_probes]),
       new ActionTalkToNPC('boy', undefined, [new MissionCompletedRequirement('sleeper_commander', 'talk_to_hostage')]),
       new ActionTalkToNPC('captain_malinoff', [new ItemRequirement(ITEMS.sleeper_module.id)], [new MissionCompletedRequirement('sleeper_commander', 'talk_to_jenkins')]),

--- a/src/requirement/CompoundRequirements.ts
+++ b/src/requirement/CompoundRequirements.ts
@@ -6,7 +6,7 @@ import { NpcTalkedInCampaignRequirement } from './NpcTalkedInCampaignRequirement
 
 export const COMPOUND_REQUIREMENTS = {
   becker_probes: new AtLeastOneRequirement([
-    new ItemRequirement(ITEMS.core_probe.id),
+    new ItemRequirement(ITEMS.core_preserver.id),
     new MissionCompletedRequirement('sleeper_commander', 'obtain_zi_data'),
     new NpcTalkedInCampaignRequirement('sleeper_commander', 'becker'),
   ]),

--- a/test/Scan.test.ts
+++ b/test/Scan.test.ts
@@ -4,23 +4,23 @@ import { ZOID_LIST } from '../src/models/Zoid';
 
 describe('calculateScanRate', () => {
   it('should return the dropRate plus probe bonus for scannable zoids', () => {
-    expect(calculateScanRate('merda', 'core_probe')).toBe(75);
-    expect(calculateScanRate('gator', 'core_probe')).toBe(60);
-    expect(calculateScanRate('malder', 'core_probe')).toBe(50);
-    expect(calculateScanRate('zatton', 'core_probe')).toBe(30);
+    expect(calculateScanRate('merda', 'core_preserver')).toBe(75);
+    expect(calculateScanRate('gator', 'core_preserver')).toBe(60);
+    expect(calculateScanRate('malder', 'core_preserver')).toBe(50);
+    expect(calculateScanRate('zatton', 'core_preserver')).toBe(30);
   });
 
   it('should return 0 for zoids with negative dropRate', () => {
     const unscannable = Object.values(ZOID_LIST).filter((z) => z.dropRate < 0);
     expect(unscannable.length).toBeGreaterThan(0);
     unscannable.forEach((z) => {
-      expect(calculateScanRate(z.id, 'core_probe')).toBe(0);
+      expect(calculateScanRate(z.id, 'core_preserver')).toBe(0);
     });
   });
 
   it('should clamp scan rate to 100', () => {
     // Merda has 75 dropRate; even with a hypothetical large bonus, rate should cap at 100
-    const rate = calculateScanRate('merda', 'core_probe');
+    const rate = calculateScanRate('merda', 'core_preserver');
     expect(rate).toBeLessThanOrEqual(100);
     expect(rate).toBeGreaterThanOrEqual(0);
   });

--- a/test/SyncDeviceItem.test.ts
+++ b/test/SyncDeviceItem.test.ts
@@ -18,14 +18,14 @@ describe('SyncDeviceItem', () => {
   });
 });
 
-describe('core_probe in ITEMS', () => {
+describe('core_preserver in ITEMS', () => {
   it('should exist with correct values', () => {
-    const probe = ITEMS.core_probe as SyncDeviceItem;
+    const preserver = ITEMS.core_preserver as SyncDeviceItem;
 
-    expect(probe).toBeDefined();
-    expect(probe.id).toBe('core_probe');
-    expect(probe.type).toBe(ItemType.Consumable);
-    expect(probe.price).toBe(100);
-    expect(probe.successBonus).toBe(0);
+    expect(preserver).toBeDefined();
+    expect(preserver.id).toBe('core_preserver');
+    expect(preserver.type).toBe(ItemType.Consumable);
+    expect(preserver.price).toBe(100);
+    expect(preserver.successBonus).toBe(0);
   });
 });

--- a/test/migrations.test.ts
+++ b/test/migrations.test.ts
@@ -3,11 +3,11 @@ import { migrate } from '../src/game/migrations';
 
 describe('migrate', () => {
   it('should return data unchanged when no migrations apply', () => {
-    const data = { landmarkId: 'test', version: '0.2.0' };
+    const data = { landmarkId: 'test', version: '0.2.1' };
 
-    const result = migrate(data, '0.2.0');
+    const result = migrate(data, '0.2.1');
 
-    expect(result).toEqual({ landmarkId: 'test', version: '0.2.0' });
+    expect(result).toEqual({ landmarkId: 'test', version: '0.2.1' });
   });
 
   it('should skip migrations older than saved version', () => {
@@ -16,6 +16,38 @@ describe('migrate', () => {
     const result = migrate(data, '1.0.0');
 
     expect(result).toEqual({ landmarkId: 'test', version: '1.0.0' });
+  });
+
+  describe('0.2.1 migration', () => {
+    it('should convert core_probe inventory to core_preserver', () => {
+      const data = { inventory: { core_probe: 3 }, landmarkId: 'test', version: '0.2.0' };
+
+      migrate(data, '0.2.0');
+
+      expect(data.inventory).toEqual({ core_preserver: 3 });
+    });
+
+    it('should merge core_probe into existing core_preserver count', () => {
+      const data = { inventory: { core_preserver: 1, core_probe: 2 }, landmarkId: 'test', version: '0.2.0' };
+
+      migrate(data, '0.2.0');
+
+      expect(data.inventory).toEqual({ core_preserver: 3 });
+    });
+
+    it('should not fail when no inventory exists', () => {
+      const data = { landmarkId: 'test', version: '0.2.0' };
+
+      expect(() => migrate(data, '0.2.0')).not.toThrow();
+    });
+
+    it('should not change inventory without core_probe', () => {
+      const data = { inventory: { core_preserver: 5 }, landmarkId: 'test', version: '0.2.0' };
+
+      migrate(data, '0.2.0');
+
+      expect(data.inventory).toEqual({ core_preserver: 5 });
+    });
   });
 
   describe('0.2.0 migration', () => {


### PR DESCRIPTION
## Summary
- Add `core_preserver` as new item replacing `core_probe` in shop, rewards, and requirements
- Update all dialogs (EN/ES) for Becker, Jenkins, and Explorer to reflect new lore: preservers extract cores from weakened zoids, Jenkins explains cloning
- Add save migration 0.2.1 converting existing `core_probe` inventory to `core_preserver`
- Update and add tests for the new item and migration

Closes #93

## Test plan
- [x] Verify shop shows Core Preserver with correct image and price
- [x] Verify Becker gift gives 5 Core Preservers
- [x] Verify battle screen shows scan rate when preserver is active
- [x] Verify dialogs read correctly in EN and ES
- [x] Verify old saves with core_probe migrate correctly
- [x] All 195 tests pass