### PR TITLE
Cancel sortie when traveling during dungeon (#102)

### DIFF
--- a/src/game/Game.test.ts
+++ b/src/game/Game.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { DungeonSortieEvent } from '../dungeon/DungeonSortieEvent';
+import { dungeonRun, endDungeon, startSortie } from '../dungeon/dungeonStore';
+import { DungeonEvent, DungeonEventChoice, HealOutcome } from '../dungeon/DungeonEventOutcome';
+import { BattleBackground, LandmarkType } from '../landmark/Landmark';
+import type { City } from '../landmark/City';
+
+const DUMMY_EVENT = new DungeonEvent('e1', 'test', [new DungeonEventChoice('ok', new HealOutcome('heal', 10))]);
+
+const DUMMY_SORTIE = new DungeonSortieEvent({
+  baseReward: { magnis: 100 },
+  bossTiers: [{ pilots: ['bandit1'] }],
+  eliteEnemies: [],
+  enemies: [{ zoidData: { id: 'gator', level: 1 } }],
+  entryCost: 0,
+  eventPool: [DUMMY_EVENT],
+  id: 'test_sortie',
+  layers: 2,
+  nodesPerLayer: [2, 3],
+  supplyOptions: [],
+});
+
+const DUMMY_CITY: City = {
+  battleBackground: BattleBackground.Grass,
+  id: 'test_city',
+  mapPosition: { x: 0, y: 0 },
+  name: 'Test City',
+  type: LandmarkType.City,
+};
+
+describe('Game.changeLocation', () => {
+  afterEach(() => {
+    if (dungeonRun()) { endDungeon(); }
+  });
+
+  it('cancels active sortie when traveling to another landmark', async () => {
+    startSortie(DUMMY_SORTIE, 100, 100);
+    expect(dungeonRun()).not.toBeNull();
+
+    const { Game } = await import('./Game');
+    const game = new Game();
+    game.changeLocation(DUMMY_CITY);
+
+    expect(dungeonRun()).toBeNull();
+  });
+});

--- a/src/game/Game.ts
+++ b/src/game/Game.ts
@@ -91,6 +91,9 @@ export class Game {
       setTimeout(() => setPopupMessage(null), 3000);
       return;
     }
+    if (dungeonRun()) {
+      this.endDungeonRun(false);
+    }
     setCurrentLandmark(landmark);
     this.wireCityActions(landmark);
     if (isRoute(landmark)) {


### PR DESCRIPTION
## Summary
- Adds a guard in `Game.changeLocation()` that cancels the active sortie (as defeat) before allowing travel to another landmark
- Fixes the bug where navigating the world map during a dungeon run would move the player without ending the sortie

Closes #102

## Test plan
- [x] Unit test verifying `changeLocation` ends the dungeon run when a sortie is active
- [x] Manual: enter a dungeon, click map to travel — sortie should end with defeat popup before moving