### PR TITLE
Fix mobile tap highlight on battle area

### DIFF
--- a/src/ui/battle.css
+++ b/src/ui/battle.css
@@ -53,6 +53,7 @@
 }
 
 .battle-area {
+  -webkit-tap-highlight-color: transparent;
   align-items: center;
   border: 2px dashed #0f3460;
   border-radius: 8px;
@@ -83,7 +84,7 @@
 }
 
 .battle-area:active {
-  background-color: rgb(0 212 255 / 5%);
+  border-color: #00d4ff;
 }
 
 .scan-rate {


### PR DESCRIPTION
## Summary
- Remove default blue tap highlight on mobile by setting `-webkit-tap-highlight-color: transparent`
- Change `:active` state to highlight the border instead of the background, matching the hover style

Closes #99