### PR TITLE
Block UI interaction during NPC dialog (#85)

### DIFF
--- a/src/story/story.css
+++ b/src/story/story.css
@@ -43,14 +43,14 @@
 /* Dialog Box */
 
 .dialog-overlay {
-  left: 50%;
-  max-width: 600px;
-  padding: 1rem;
+  align-items: flex-start;
+  background: rgb(0 0 0 / 60%);
+  display: flex;
+  inset: 0;
+  justify-content: center;
+  padding-top: 4rem;
   position: fixed;
-  top: 4rem;
-  transform: translateX(-50%);
-  width: 100%;
-  z-index: 10;
+  z-index: 100;
 }
 
 .dialog-box {
@@ -58,9 +58,10 @@
   border: 2px solid #0f3460;
   border-radius: 12px;
   cursor: pointer;
+  max-width: 600px;
   padding: 1.5rem;
   user-select: none;
-  width: 100%;
+  width: 90%;
 }
 
 .dialog-content {


### PR DESCRIPTION
## Summary
- Applies full-screen modal overlay to NPC dialogs, matching the existing pattern used by shop, inventory, and archive panels
- Blocks all UI interaction while a dialog is active — prevents opening multiple dialogs or clicking other buttons

Closes #85

## Test plan
- [x] Trigger an NPC dialog and verify the dark overlay covers the entire screen
- [x] Confirm clicking outside the dialog box does nothing
- [x] Confirm clicking the dialog box advances text normally
- [x] Verify dialog completes and overlay disappears, restoring full interaction
- [x] Test queued dialogs (one completes, next appears)
- [x] Test on mobile — no tap-through to other elements