### PR TITLE
Add commander zoid selection to party panel (#43)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zoids-sleeper",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zoids-sleeper",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "dependencies": {
         "i18next": "^26.0.3",
         "solid-js": "^1.9.11"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zoids-sleeper",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -124,10 +124,10 @@ const App: Component = () => {
           labId={activeLab()!.labId}
           onBuy={(zoidId) => {
             const zoid = ZOID_LIST[zoidId];
-            const isFirstFree = party().length === 1 && !isMissionCompleted('sleeper_commander', 'grow_army');
+            const isFirstFree = party().zoids.length === 1 && !isMissionCompleted('sleeper_commander', 'grow_army');
             const price = isFirstFree ? 0 : zoid.price;
             if (getCurrency(Currency.Magnis) >= price) {
-              const isNew = !party().some((z) => z.id === zoidId);
+              const isNew = !party().zoids.some((z) => z.id === zoidId);
               addCurrency(Currency.Magnis, -price);
               decrementZoidData(zoidId);
               addZoidToArmy(zoidId);

--- a/src/game/BaseBattle.ts
+++ b/src/game/BaseBattle.ts
@@ -77,9 +77,9 @@ export abstract class BaseBattle {
   protected awardExperience(): void {
     const enemyData = getZoidById(this.enemy.id);
     const xpGain = calculateExperienceGain(enemyData.baseExp, this.enemy.level, this.isPilotBattle);
-    const previousLevels = party().map((z) => getOwnedZoidLevel(z));
-    setParty(awardExperience(party(), xpGain));
-    const totalGained = party().reduce((sum, z, i) =>
+    const previousLevels = party().zoids.map((z) => getOwnedZoidLevel(z));
+    setParty((prev) => ({ ...prev, zoids: awardExperience(prev.zoids, xpGain) }));
+    const totalGained = party().zoids.reduce((sum, z, i) =>
       sum + Math.floor(getOwnedZoidLevel(z) / 10) - Math.floor(previousLevels[i] / 10), 0);
     if (totalGained > 0) {
       incrementClickAttack(totalGained);

--- a/src/game/Game.ts
+++ b/src/game/Game.ts
@@ -359,7 +359,7 @@ export class Game {
     const data = this.save.load();
     if (data) {
       setShowClickHint(false);
-      if (data.party?.length) {
+      if (data.party?.zoids?.length) {
         setParty(data.party);
       }
       if (data.routeKills || data.pilotDefeats) {
@@ -380,7 +380,7 @@ export class Game {
       if (data.zoidResearch) {
         loadZoidResearch(data.zoidResearch);
       }
-      data.party?.forEach((z) => updateZoidResearch(z.id, ZoidResearchStatus.Created));
+      data.party?.zoids.forEach((z) => updateZoidResearch(z.id, ZoidResearchStatus.Created));
       loadCampaigns(CAMPAIGNS, data.campaigns ?? {});
       return true;
     }

--- a/src/game/Save.ts
+++ b/src/game/Save.ts
@@ -1,7 +1,7 @@
 import { SAVE_TICK, TICK_TIME } from '../constants';
 import type { CampaignSaveData } from '../campaign/Campaign';
 import type { PlayerStats } from '../models/Player';
-import type { OwnedZoid } from '../models/Zoid';
+import type { PartyData } from '../models/Zoid';
 import type { ZoidResearchStatus } from '../models/Zoid';
 import { campaignStates } from '../store/campaignStore';
 import { playerStats } from '../store/gameStore';
@@ -20,7 +20,7 @@ export interface SaveData {
   campaigns?: Record<string, CampaignSaveData>;
   inventory?: Record<string, number>;
   landmarkId: string;
-  party?: OwnedZoid[];
+  party?: PartyData;
   pilotDefeats?: Record<string, number>;
   playerStats?: PlayerStats;
   routeKills?: Record<string, number>;

--- a/src/game/Scan.ts
+++ b/src/game/Scan.ts
@@ -17,7 +17,7 @@ export function attemptScan(zoidId: string, probeId: string): boolean {
 
   if (Math.random() * 100 < rate) {
     const isNew = getZoidDataCount(zoidId) === 0;
-    const inParty = party().some((z) => z.id === zoidId);
+    const inParty = party().zoids.some((z) => z.id === zoidId);
     incrementZoidData(zoidId);
     updateZoidResearch(zoidId, ZoidResearchStatus.Scanned);
     if (isNew && !inParty) {

--- a/src/game/migrations.ts
+++ b/src/game/migrations.ts
@@ -1,4 +1,5 @@
 import { CAMPAIGNS } from '../campaign/campaigns';
+import type { OwnedZoid } from '../models/Zoid';
 import type { SaveData } from './Save';
 
 export type MigrationData = Partial<SaveData> & Record<string, unknown>;
@@ -6,6 +7,15 @@ export type MigrationData = Partial<SaveData> & Record<string, unknown>;
 type MigrationFn = (data: MigrationData) => void;
 
 const migrations: Record<string, MigrationFn> = {
+  '0.4.1': (data) => {
+    if (Array.isArray(data.party)) {
+      const zoids = data.party as OwnedZoid[];
+      const commanderZoidId = zoids.length > 0
+        ? zoids.reduce((best, z) => z.experience > best.experience ? z : best).id
+        : '';
+      data.party = { commanderZoidId, zoids };
+    }
+  },
   '0.4.0': (data) => {
     const campaign = data.campaigns?.['sleeper_commander'];
     if (!campaign) {return;}

--- a/src/i18n/locales/en/ui.json
+++ b/src/i18n/locales/en/ui.json
@@ -19,6 +19,7 @@
   "click_to_continue": "Click to continue...",
   "defeated": "Defeated!",
   "depot": "Depot",
+  "commander_badge": "COMMANDER",
   "download_save": "Download Save",
   "duel_pilot": "Duel {{name}}",
   "enemy_turn": "Enemy Turn",

--- a/src/i18n/locales/es/ui.json
+++ b/src/i18n/locales/es/ui.json
@@ -19,6 +19,7 @@
   "click_to_continue": "Haz clic para continuar...",
   "defeated": "¡Derrotado!",
   "depot": "Depósito",
+  "commander_badge": "COMANDANTE",
   "download_save": "Descargar partida",
   "duel_pilot": "Duelo contra {{name}}",
   "enemy_turn": "Turno Enemigo",

--- a/src/models/Zoid.ts
+++ b/src/models/Zoid.ts
@@ -116,4 +116,9 @@ export function buildZoid({ attackOverride, bonusMultiplier = 1, id, imageOverri
   };
 }
 
-export const DEFAULT_PARTY: OwnedZoid[] = [];
+export interface PartyData {
+  commanderZoidId: string;
+  zoids: OwnedZoid[];
+}
+
+export const DEFAULT_PARTY: PartyData = { commanderZoidId: '', zoids: [] };

--- a/src/requirement/ArmySizeRequirement.ts
+++ b/src/requirement/ArmySizeRequirement.ts
@@ -22,6 +22,6 @@ export class ArmySizeRequirement implements Requirement {
   }
 
   progress(): number {
-    return party().length;
+    return party().zoids.length;
   }
 }

--- a/src/store/partyStore.ts
+++ b/src/store/partyStore.ts
@@ -1,32 +1,43 @@
 import { createMemo, createSignal } from 'solid-js';
-import { buildZoid, calculatePartyAttack, calculatePartyMaxHealth, type CustomizedZoid, DEFAULT_PARTY, getOwnedZoidLevel, type OwnedZoid, ZoidResearchStatus } from '../models/Zoid';
+import { buildZoid, calculatePartyAttack, calculatePartyMaxHealth, type CustomizedZoid, DEFAULT_PARTY, getOwnedZoidLevel, type PartyData, ZoidResearchStatus } from '../models/Zoid';
 import { incrementClickAttack } from './gameStore';
 import { updateZoidResearch } from './zoidResearchStore';
 
-const [party, setParty] = createSignal<OwnedZoid[]>(DEFAULT_PARTY);
+const [party, setParty] = createSignal<PartyData>(DEFAULT_PARTY);
 
-const partyAttack = createMemo(() => calculatePartyAttack(party()));
-const partyMaxHealth = createMemo(() => calculatePartyMaxHealth(party()));
+const partyAttack = createMemo(() => calculatePartyAttack(party().zoids));
+const partyMaxHealth = createMemo(() => calculatePartyMaxHealth(party().zoids));
 
 function addZoidToArmy(zoidId: string, experience = 0): void {
   setParty((prev) => {
-    const existing = prev.find((z) => z.id === zoidId);
+    const existing = prev.zoids.find((z) => z.id === zoidId);
     if (existing) {
-      return prev.map((z) => z.id === zoidId
-        ? { ...z, copies: (z.copies ?? 1) + 1 }
-        : z);
+      return {
+        ...prev,
+        zoids: prev.zoids.map((z) => z.id === zoidId
+          ? { ...z, copies: (z.copies ?? 1) + 1 }
+          : z),
+      };
     }
-    return [...prev, { experience, id: zoidId }];
+    return {
+      commanderZoidId: prev.zoids.length === 0 ? zoidId : prev.commanderZoidId,
+      zoids: [...prev.zoids, { experience, id: zoidId }],
+    };
   });
   incrementClickAttack();
   updateZoidResearch(zoidId, ZoidResearchStatus.Created);
 }
 
 function findStrongestZoid(): CustomizedZoid {
-  const partyZoids = party();
-  if (partyZoids.length === 0) {throw new Error('Party is empty');}
-  const strongest = partyZoids.reduce((best, z) => z.experience > best.experience ? z : best);
-  return buildZoid({ id: strongest.id, level: getOwnedZoidLevel(strongest) });
+  const { commanderZoidId, zoids } = party();
+  if (zoids.length === 0) {throw new Error('Party is empty');}
+  const commander = zoids.find((z) => z.id === commanderZoidId);
+  const chosen = commander ?? zoids.reduce((best, z) => z.experience > best.experience ? z : best);
+  return buildZoid({ id: chosen.id, level: getOwnedZoidLevel(chosen) });
 }
 
-export { addZoidToArmy, findStrongestZoid, party, partyAttack, partyMaxHealth, setParty };
+function selectCommanderZoid(zoidId: string): void {
+  setParty((prev) => ({ ...prev, commanderZoidId: zoidId }));
+}
+
+export { addZoidToArmy, findStrongestZoid, party, partyAttack, partyMaxHealth, selectCommanderZoid, setParty };

--- a/src/ui/LabPanel.tsx
+++ b/src/ui/LabPanel.tsx
@@ -43,7 +43,7 @@ const LabPanel: Component<LabPanelProps> = (props) => {
           <div class="archive-grid">
             <For each={availableZoids()}>
               {(entry) => {
-                const isFirstFree = () => party().length === 1 && !isMissionCompleted('sleeper_commander', 'grow_army');
+                const isFirstFree = () => party().zoids.length === 1 && !isMissionCompleted('sleeper_commander', 'grow_army');
                 const canAfford = () => isFirstFree() || getCurrency(Currency.Magnis) >= entry.data.price;
                 return (
                   <button

--- a/src/ui/PartyPanel.tsx
+++ b/src/ui/PartyPanel.tsx
@@ -1,8 +1,9 @@
-import { createSignal, For, Show, type Component } from 'solid-js';
+import { createMemo, createSignal, For, Show, type Component } from 'solid-js';
 import { t } from '../i18n';
 import { experienceForLevel, MAX_LEVEL } from '../models/LevelType';
 import { getOwnedZoidLevel, getZoidById, getZoidImage, buildZoid, type OwnedZoid } from '../models/Zoid';
-import { party } from '../store/partyStore';
+import { isMissionCompleted } from '../store/campaignStore';
+import { party, selectCommanderZoid } from '../store/partyStore';
 import './party.css';
 
 const StatOption = {
@@ -55,6 +56,12 @@ interface PartyPanelProps {
 
 const PartyPanel: Component<PartyPanelProps> = (props) => {
   const [selectedStat, setSelectedStat] = createSignal<StatOption>(StatOption.Attack);
+  const isDuelUnlocked = createMemo(() => isMissionCompleted('sleeper_commander', 'find_van_oasis'));
+  const commanderZoidId = createMemo(() => {
+    const zoids = party().zoids;
+    if (zoids.length <= 1 || !isDuelUnlocked()) {return null;}
+    return party().commanderZoidId;
+  });
 
   return (
     <div class="party-panel">
@@ -70,11 +77,16 @@ const PartyPanel: Component<PartyPanelProps> = (props) => {
           </For>
         </select>
         <div class="party-list">
-          <For each={party()}>
+          <For each={party().zoids}>
             {(zoid) => {
               const level = () => getOwnedZoidLevel(zoid);
+              const isCommander = () => zoid.id === commanderZoidId();
               return (
-                <div class="party-row">
+                <div
+                  class="party-row"
+                  classList={{ 'party-row-selected': isCommander() }}
+                  onClick={() => isDuelUnlocked() && selectCommanderZoid(zoid.id)}
+                >
                   <div class="party-row-image-col">
                     <img class="party-row-image" src={getZoidImage(zoid.id)} alt={getZoidById(zoid.id).name} />
                     <Show when={level() < MAX_LEVEL}>
@@ -86,6 +98,9 @@ const PartyPanel: Component<PartyPanelProps> = (props) => {
                   <div class="party-row-info">
                     <span class="party-row-name">{getZoidById(zoid.id).name}</span>
                     <span class="party-row-level">{t('ui:lv')}{level()}</span>
+                    <Show when={isCommander()}>
+                      <span class="party-row-commander-badge">{t('ui:commander_badge')}</span>
+                    </Show>
                   </div>
                   <span class="party-row-stat">{getStatValue(zoid, selectedStat())}</span>
                 </div>

--- a/src/ui/party.css
+++ b/src/ui/party.css
@@ -37,12 +37,14 @@
 .party-list {
   display: flex;
   flex-direction: column;
+  max-height: 420px;
   overflow-y: auto;
 }
 
 .party-row {
   align-items: center;
   border-bottom: 1px solid #0f3460;
+  cursor: pointer;
   display: grid;
   gap: 0.25rem;
   grid-template-columns: 40px 1fr 1fr;
@@ -51,6 +53,35 @@
 
 .party-row:last-child {
   border-bottom: none;
+}
+
+.party-row:nth-child(even) {
+  background: rgb(255 255 255 / 3%);
+}
+
+.party-row:hover {
+  background: rgb(0 212 255 / 8%);
+}
+
+.party-row-selected {
+  background: rgb(0 212 255 / 5%);
+  border-left: 2px solid #00d4ff;
+}
+
+.party-row-selected:nth-child(even) {
+  background: rgb(0 212 255 / 5%);
+}
+
+.party-row-commander-badge {
+  background: #00d4ff;
+  border-radius: 3px;
+  color: #1a1a2e;
+  font-size: 0.55rem;
+  font-weight: bold;
+  letter-spacing: 0.5px;
+  padding: 1px 4px;
+  text-transform: uppercase;
+  width: fit-content;
 }
 
 .party-row-image {
@@ -105,4 +136,10 @@
   border-radius: 2px;
   height: 100%;
   transition: width 0.3s;
+}
+
+@media (width <= 768px) {
+  .party-list {
+    max-height: 126px;
+  }
 }

--- a/test/ArmySizeRequirement.test.ts
+++ b/test/ArmySizeRequirement.test.ts
@@ -1,21 +1,22 @@
 import { beforeEach, describe, expect, it } from 'vitest';
+import { DEFAULT_PARTY } from '../src/models/Zoid';
 import { ArmySizeRequirement, ComparisonCondition } from '../src/requirement';
 import { setParty } from '../src/store/partyStore';
 
 describe('ArmySizeRequirement', () => {
   beforeEach(() => {
-    setParty([]);
+    setParty(DEFAULT_PARTY);
   });
 
   it('should not be completed when army is too small', () => {
-    setParty([{ experience: 0, id: 'molga' }]);
+    setParty({ commanderZoidId: 'molga', zoids: [{ experience: 0, id: 'molga' }] });
     const req = new ArmySizeRequirement(ComparisonCondition.AtLeast, 2);
 
     expect(req.isCompleted()).toBe(false);
   });
 
   it('should be completed when army size meets condition', () => {
-    setParty([{ experience: 0, id: 'molga' }, { experience: 0, id: 'gator' }]);
+    setParty({ commanderZoidId: 'molga', zoids: [{ experience: 0, id: 'molga' }, { experience: 0, id: 'gator' }] });
     const req = new ArmySizeRequirement(ComparisonCondition.AtLeast, 2);
 
     expect(req.isCompleted()).toBe(true);
@@ -28,7 +29,7 @@ describe('ArmySizeRequirement', () => {
   });
 
   it('should return current army size as progress', () => {
-    setParty([{ experience: 0, id: 'molga' }, { experience: 0, id: 'gator' }, { experience: 0, id: 'merda' }]);
+    setParty({ commanderZoidId: 'molga', zoids: [{ experience: 0, id: 'molga' }, { experience: 0, id: 'gator' }, { experience: 0, id: 'merda' }] });
     const req = new ArmySizeRequirement(ComparisonCondition.AtLeast, 5);
 
     expect(req.progress()).toBe(3);

--- a/test/DuelBattle.test.ts
+++ b/test/DuelBattle.test.ts
@@ -11,7 +11,7 @@ import { calculateAimMultiplier, DuelBattle, GaugeDirection } from '../src/game/
 import { PILOTS } from '../src/models/Pilot';
 import { DEFAULT_PLAYER } from '../src/models/Player';
 import { DuelTurnPhase, setPlayerStats } from '../src/store/gameStore';
-import { setParty } from '../src/store/partyStore';
+import { selectCommanderZoid, setParty } from '../src/store/partyStore';
 import { loadStatistics } from '../src/store/statisticsStore';
 import { loadZoidResearch } from '../src/store/zoidResearchStore';
 
@@ -28,7 +28,7 @@ function advanceTicks(battle: DuelBattle, count: number): void {
 describe('DuelBattle', () => {
   beforeEach(() => {
     setPlayerStats(DEFAULT_PLAYER);
-    setParty([{ experience: 1000, id: 'shield_liger' }, { experience: 500, id: 'molga' }]);
+    setParty({ commanderZoidId: 'shield_liger', zoids: [{ experience: 1000, id: 'shield_liger' }, { experience: 500, id: 'molga' }] });
     loadStatistics({}, {});
     loadZoidResearch({});
   });
@@ -37,6 +37,14 @@ describe('DuelBattle', () => {
     const battle = new DuelBattle(DEFAULT_PLAYER, PILOTS['van_shield_liger']);
 
     expect(battle.playerZoid.id).toBe('shield_liger');
+  });
+
+  it('should use commanderZoidId instead of strongest', () => {
+    selectCommanderZoid('molga');
+
+    const battle = new DuelBattle(DEFAULT_PLAYER, PILOTS['van_shield_liger']);
+
+    expect(battle.playerZoid.id).toBe('molga');
   });
 
   it('should start in PlayerTapping phase', () => {

--- a/test/PartyStore.test.ts
+++ b/test/PartyStore.test.ts
@@ -1,13 +1,14 @@
 import { beforeEach, describe, expect, it } from 'vitest';
+import { DEFAULT_PARTY } from '../src/models/Zoid';
 import { DEFAULT_PLAYER } from '../src/models/Player';
 import { ZoidResearchStatus } from '../src/models/Zoid';
 import { playerStats, setPlayerStats } from '../src/store/gameStore';
-import { addZoidToArmy, party, setParty } from '../src/store/partyStore';
+import { addZoidToArmy, findStrongestZoid, party, selectCommanderZoid, setParty } from '../src/store/partyStore';
 import { getZoidResearch, loadZoidResearch } from '../src/store/zoidResearchStore';
 
 describe('PartyStore - addZoidToArmy', () => {
   beforeEach(() => {
-    setParty([]);
+    setParty(DEFAULT_PARTY);
     setPlayerStats(DEFAULT_PLAYER);
     loadZoidResearch({});
   });
@@ -15,19 +16,19 @@ describe('PartyStore - addZoidToArmy', () => {
   it('should add a zoid to the party', () => {
     addZoidToArmy('molga');
 
-    expect(party().some((z) => z.id === 'molga')).toBe(true);
+    expect(party().zoids.some((z) => z.id === 'molga')).toBe(true);
   });
 
   it('should add a zoid with 0 experience by default', () => {
     addZoidToArmy('molga');
 
-    expect(party().find((z) => z.id === 'molga')?.experience).toBe(0);
+    expect(party().zoids.find((z) => z.id === 'molga')?.experience).toBe(0);
   });
 
   it('should add a zoid with custom experience', () => {
     addZoidToArmy('molga', 500);
 
-    expect(party().find((z) => z.id === 'molga')?.experience).toBe(500);
+    expect(party().zoids.find((z) => z.id === 'molga')?.experience).toBe(500);
   });
 
   it('should update research to created', () => {
@@ -46,14 +47,14 @@ describe('PartyStore - addZoidToArmy', () => {
     addZoidToArmy('molga');
     addZoidToArmy('molga');
 
-    expect(party().filter((z) => z.id === 'molga')).toHaveLength(1);
+    expect(party().zoids.filter((z) => z.id === 'molga')).toHaveLength(1);
   });
 
   it('should increment copies when adding a duplicate zoid', () => {
     addZoidToArmy('molga');
     addZoidToArmy('molga');
 
-    expect(party().find((z) => z.id === 'molga')?.copies).toBe(2);
+    expect(party().zoids.find((z) => z.id === 'molga')?.copies).toBe(2);
   });
 
   it('should still increment click attack on duplicate purchase', () => {
@@ -67,6 +68,62 @@ describe('PartyStore - addZoidToArmy', () => {
     addZoidToArmy('molga');
     addZoidToArmy('gator');
 
-    expect(party()).toHaveLength(2);
+    expect(party().zoids).toHaveLength(2);
+  });
+
+  it('should set commanderZoidId when adding first zoid', () => {
+    addZoidToArmy('molga');
+
+    expect(party().commanderZoidId).toBe('molga');
+  });
+
+  it('should not change commanderZoidId when adding subsequent zoids', () => {
+    addZoidToArmy('molga');
+    addZoidToArmy('gator');
+
+    expect(party().commanderZoidId).toBe('molga');
+  });
+});
+
+describe('PartyStore - selectCommanderZoid', () => {
+  beforeEach(() => {
+    setParty({ commanderZoidId: 'molga', zoids: [{ experience: 0, id: 'molga' }, { experience: 0, id: 'gator' }] });
+    setPlayerStats(DEFAULT_PLAYER);
+    loadZoidResearch({});
+  });
+
+  it('should update commanderZoidId', () => {
+    selectCommanderZoid('gator');
+
+    expect(party().commanderZoidId).toBe('gator');
+  });
+});
+
+describe('PartyStore - findStrongestZoid', () => {
+  beforeEach(() => {
+    setPlayerStats(DEFAULT_PLAYER);
+    loadZoidResearch({});
+  });
+
+  it('should return commanderZoidId zoid', () => {
+    setParty({ commanderZoidId: 'molga', zoids: [{ experience: 1000, id: 'shield_liger' }, { experience: 500, id: 'molga' }] });
+
+    const result = findStrongestZoid();
+
+    expect(result.id).toBe('molga');
+  });
+
+  it('should fall back to highest XP when commanderZoidId not in zoids', () => {
+    setParty({ commanderZoidId: 'nonexistent', zoids: [{ experience: 1000, id: 'shield_liger' }, { experience: 500, id: 'molga' }] });
+
+    const result = findStrongestZoid();
+
+    expect(result.id).toBe('shield_liger');
+  });
+
+  it('should throw when party is empty', () => {
+    setParty(DEFAULT_PARTY);
+
+    expect(() => findStrongestZoid()).toThrow('Party is empty');
   });
 });

--- a/test/Save.test.ts
+++ b/test/Save.test.ts
@@ -111,7 +111,9 @@ describe('Save', () => {
       const result = await Save.importSave(file);
 
       expect(result).toBe(true);
-      expect(localStorage.getItem('zoids-sleeper-save')).toBe(saveJson);
+      const stored = JSON.parse(localStorage.getItem('zoids-sleeper-save')!);
+      expect(stored.landmarkId).toBe('test_city');
+      expect(stored.party).toEqual({ commanderZoidId: '', zoids: [] });
       expect(location.reload).toHaveBeenCalledOnce();
     });
 

--- a/test/migrations.test.ts
+++ b/test/migrations.test.ts
@@ -184,6 +184,59 @@ describe('migrate', () => {
     });
   });
 
+  describe('0.4.1 migration', () => {
+    it('should convert party array to PartyData', () => {
+      const data = {
+        landmarkId: 'test',
+        party: [{ experience: 1000, id: 'shield_liger' }, { experience: 500, id: 'molga' }],
+        version: '0.4.0',
+      };
+
+      migrate(data, '0.4.0');
+
+      expect(data.party).toEqual({
+        commanderZoidId: 'shield_liger',
+        zoids: [{ experience: 1000, id: 'shield_liger' }, { experience: 500, id: 'molga' }],
+      });
+    });
+
+    it('should pick strongest zoid as commander', () => {
+      const data = {
+        landmarkId: 'test',
+        party: [{ experience: 100, id: 'molga' }, { experience: 999, id: 'gator' }],
+        version: '0.4.0',
+      };
+
+      migrate(data, '0.4.0');
+
+      expect((data.party as { commanderZoidId: string }).commanderZoidId).toBe('gator');
+    });
+
+    it('should handle empty party array', () => {
+      const data = {
+        landmarkId: 'test',
+        party: [],
+        version: '0.4.0',
+      };
+
+      migrate(data, '0.4.0');
+
+      expect(data.party).toEqual({ commanderZoidId: '', zoids: [] });
+    });
+
+    it('should not modify already-migrated party', () => {
+      const data = {
+        landmarkId: 'test',
+        party: { commanderZoidId: 'molga', zoids: [{ experience: 0, id: 'molga' }] },
+        version: '0.4.0',
+      };
+
+      migrate(data, '0.4.0');
+
+      expect(data.party).toEqual({ commanderZoidId: 'molga', zoids: [{ experience: 0, id: 'molga' }] });
+    });
+  });
+
   describe('0.2.0 migration', () => {
     it('should reset completed campaign to interrogate_bandits', () => {
       const data = {


### PR DESCRIPTION
## Summary
- Introduces `PartyData` type replacing the raw `OwnedZoid[]` party signal, adding a `commanderZoidId` field to track which zoid the player selects for duel battles
- Party panel now shows a "COMMANDER" badge on the selected zoid and allows clicking to switch selection (only visible after Van duel is unlocked and party has 2+ zoids)
- Improves party panel visuals: alternating row colors, max-height with scroll (10 rows desktop, 3 mobile), hover effects
- Adds save migration `0.4.1` to convert old party arrays to the new `PartyData` format

## Test plan
- [x] All 268 existing + new unit tests pass
- [x] Verify badge appears only after Van duel unlock with 2+ zoids
- [x] Click different zoid → badge moves, next duel uses selected zoid
- [x] Reload page → selection persists
- [x] Single zoid party → no badge shown
- [x] Old save migrates correctly (strongest zoid becomes commander)
- [x] Alternating row colors and scroll behavior on desktop and mobile

Closes #43