### PR TITLE
Add mission completed popup and panel animation (#82)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,7 +30,7 @@ import {
   setActiveDialog,
   setActiveLab,
   setActiveShop,
-  setPopupMessage,
+  showPopup,
 } from './store/gameStore';
 import DialogBox from './story/DialogBox';
 import IntroSequence from './story/IntroSequence';
@@ -133,8 +133,7 @@ const App: Component = () => {
               addZoidToArmy(zoidId);
               checkCampaigns();
               if (isNew) {
-                setPopupMessage(new PopupMessage(zoid.name, t('ui:new_zoid'), PopupType.Item, getZoidImage(zoidId)));
-                setTimeout(() => setPopupMessage(null), 3000);
+                showPopup(new PopupMessage(zoid.name, t('ui:new_zoid'), PopupType.Item, getZoidImage(zoidId)));
               }
             }
           }}
@@ -234,22 +233,22 @@ const App: Component = () => {
           </div>
         </div>
       </Show>
-      <Show when={popupMessage()}>
-        <div
-          class={`popup-message ${popupMessage()!.type === PopupType.Defeat ? 'popup-defeat' : popupMessage()!.type === PopupType.Item ? 'popup-item' : ''}`}
-        >
-          <Show when={popupMessage()!.image}>
-            <img
-              class="popup-message-img"
-              src={popupMessage()!.image}
-              alt=""
-            />
-          </Show>
-          <div>
-            <h2>{popupMessage()!.title}</h2>
-            <p>{popupMessage()!.content}</p>
+      <Show when={popupMessage()} keyed>
+        {(popup) => (
+          <div class={`popup-message popup-${popup.type}`}>
+            <Show when={popup.image}>
+              <img
+                class="popup-message-img"
+                src={popup.image}
+                alt=""
+              />
+            </Show>
+            <div>
+              <h2>{popup.title}</h2>
+              <p>{popup.content}</p>
+            </div>
           </div>
-        </div>
+        )}
       </Show>
     </div>
   );

--- a/src/game/Game.ts
+++ b/src/game/Game.ts
@@ -47,7 +47,7 @@ import {
   setActiveShop,
   emitRewardEvent,
   setDuelState,
-  setPopupMessage,
+  showPopup,
   setRewardEvents,
 } from '../store/gameStore';
 import { setCurrentLandmark } from '../store/landmarkStore';
@@ -92,8 +92,7 @@ export class Game {
   changeLocation(landmark: Landmark): void {
     if (!isLandmarkUnlocked(landmark)) {
       const hints = getLandmarkHints(landmark);
-      setPopupMessage(new PopupMessage(hints.join('\n'), t('ui:locked'), PopupType.Defeat));
-      setTimeout(() => setPopupMessage(null), 3000);
+      showPopup(new PopupMessage(hints.join('\n'), t('ui:locked'), PopupType.Defeat));
       return;
     }
     if (dungeonRun()) {
@@ -133,12 +132,12 @@ export class Game {
     setPilotZoidIds([]);
     if (victory) {
       checkCampaigns();
-      setPopupMessage(new PopupMessage(t('ui:sortie_complete'), t('ui:victory'), PopupType.Victory));
+      showPopup(new PopupMessage(t('ui:sortie_complete'), t('ui:victory'), PopupType.Victory));
     } else {
-      setPopupMessage(new PopupMessage(t('ui:sortie_failed'), t('ui:defeated'), PopupType.Defeat));
+      showPopup(new PopupMessage(t('ui:sortie_failed'), t('ui:defeated'), PopupType.Defeat));
     }
     endDungeon();
-    setTimeout(() => setPopupMessage(null), 3000);
+
   }
 
   enterDungeon(sortieEvent: DungeonSortieEvent): void {
@@ -259,8 +258,8 @@ export class Game {
     this.battle = null;
     setBattleState(BattleState.Idle);
     setEnemyZoid(null);
-    setPopupMessage(popup);
-    setTimeout(() => setPopupMessage(null), 3000);
+    showPopup(popup);
+
   }
 
   private endPilotBattle(popup: PopupMessage): void {
@@ -272,8 +271,8 @@ export class Game {
     this.battle = null;
     setBattleState(BattleState.Idle);
     setEnemyZoid(null);
-    setPopupMessage(popup);
-    setTimeout(() => setPopupMessage(null), 3000);
+    showPopup(popup);
+
   }
 
   private gameTick(): void {

--- a/src/game/Scan.ts
+++ b/src/game/Scan.ts
@@ -2,7 +2,7 @@ import { t } from '../i18n';
 import { ITEMS, SyncDeviceItem } from '../item';
 import { PopupMessage, PopupType } from '../models/PopupMessage';
 import { getZoidById, getZoidImage, ZoidResearchStatus } from '../models/Zoid';
-import { setPopupMessage } from '../store/gameStore';
+import { showPopup } from '../store/gameStore';
 import { getItemCount, inventory, removeItem } from '../store/inventoryStore';
 import { party } from '../store/partyStore';
 import { getZoidDataCount, incrementZoidData } from '../store/zoidDataStore';
@@ -22,8 +22,7 @@ export function attemptScan(zoidId: string, probeId: string): boolean {
     updateZoidResearch(zoidId, ZoidResearchStatus.Scanned);
     if (isNew && !inParty) {
       const zoidData = getZoidById(zoidId);
-      setPopupMessage(new PopupMessage(zoidData.name, t('ui:new_zdata'), PopupType.Item, getZoidImage(zoidId)));
-      setTimeout(() => setPopupMessage(null), 3000);
+      showPopup(new PopupMessage(zoidData.name, t('ui:new_zdata'), PopupType.Item, getZoidImage(zoidId)));
     }
     return true;
   }

--- a/src/i18n/locales/en/ui.json
+++ b/src/i18n/locales/en/ui.json
@@ -62,6 +62,7 @@
   "stat_hp_100": "HP at Lv 100",
   "campaign_completed": "Completed",
   "deploy": "Deploy",
+  "mission_completed": "Mission Completed!",
   "mission_progress": "Mission {{current}}/{{total}}",
   "new_item": "New Item Obtained!",
   "new_zoid": "New Zoid Deployed!",

--- a/src/i18n/locales/es/ui.json
+++ b/src/i18n/locales/es/ui.json
@@ -62,6 +62,7 @@
   "stat_hp_100": "Vida al Nv 100",
   "campaign_completed": "Completada",
   "deploy": "Desplegar",
+  "mission_completed": "¡Misión cumplida!",
   "mission_progress": "Misión {{current}}/{{total}}",
   "new_item": "¡Nuevo objeto obtenido!",
   "new_zoid": "¡Nuevo Zoid desplegado!",

--- a/src/index.css
+++ b/src/index.css
@@ -98,6 +98,14 @@ body {
   color: #00d4ff;
 }
 
+.popup-mission {
+  border-color: #00d4ff;
+}
+
+.popup-mission h2 {
+  color: #00d4ff;
+}
+
 .popup-message h2 {
   color: #ffd700;
   font-size: 1rem;

--- a/src/models/PopupMessage.ts
+++ b/src/models/PopupMessage.ts
@@ -1,4 +1,4 @@
-export const PopupType = { Defeat: 'defeat', Item: 'item', Victory: 'victory' } as const;
+export const PopupType = { Defeat: 'defeat', Item: 'item', Mission: 'mission', Victory: 'victory' } as const;
 export type PopupType = (typeof PopupType)[keyof typeof PopupType];
 
 export class PopupMessage {

--- a/src/store/campaignStore.ts
+++ b/src/store/campaignStore.ts
@@ -1,34 +1,42 @@
 import { createSignal } from 'solid-js';
 import { CampaignStatus, type Campaign, type CampaignSaveData } from '../campaign/Campaign';
+import { t } from '../i18n';
+import { PopupMessage, PopupType } from '../models/PopupMessage';
 import { NpcTalkedInCampaignRequirement } from '../requirement/NpcTalkedInCampaignRequirement';
+import { showPopup } from './gameStore';
 
 let campaigns: Record<string, Campaign> = {};
 
 const [campaignStates, setCampaignStates] = createSignal<Record<string, CampaignSaveData>>({});
 
 function advanceMission(campaignId: string): void {
-  setCampaignStates((prev) => {
-    const state = prev[campaignId];
-    if (!state || state.status !== CampaignStatus.Started) {return prev;}
+  const state = campaignStates()[campaignId];
+  if (!state || state.status !== CampaignStatus.Started) {return;}
 
-    const campaign = campaigns[campaignId];
-    if (!campaign) {return prev;}
+  const campaign = campaigns[campaignId];
+  if (!campaign) {return;}
 
-    const currentIndex = getMissionIndex(campaign, state.currentMission);
-    if (currentIndex < 0) {return prev;}
+  const currentIndex = getMissionIndex(campaign, state.currentMission);
+  if (currentIndex < 0) {return;}
 
-    campaign.missions[currentIndex]?.onComplete?.();
+  const completedMissionId = state.currentMission;
+  campaign.missions[currentIndex]?.onComplete?.();
 
-    const nextIndex = currentIndex + 1;
-    const completed = nextIndex >= campaign.missions.length;
-    const nextMissionId = campaign.missions[nextIndex]?.id ?? '';
+  const nextIndex = currentIndex + 1;
+  const completed = nextIndex >= campaign.missions.length;
+  const nextMissionId = campaign.missions[nextIndex]?.id ?? '';
 
-    const newState: CampaignSaveData = completed
-      ? { currentMission: '', status: CampaignStatus.Completed }
-      : { currentMission: nextMissionId, missionNpcFlags: buildNpcFlags(campaign, nextIndex), status: CampaignStatus.Started };
+  const newState: CampaignSaveData = completed
+    ? { currentMission: '', status: CampaignStatus.Completed }
+    : { currentMission: nextMissionId, missionNpcFlags: buildNpcFlags(campaign, nextIndex), status: CampaignStatus.Started };
 
-    return { ...prev, [campaignId]: newState };
-  });
+  setCampaignStates((prev) => ({ ...prev, [campaignId]: newState }));
+
+  showPopup(new PopupMessage(
+    t(`campaigns:${campaignId}.missions.${completedMissionId}.name`),
+    t('ui:mission_completed'),
+    PopupType.Mission
+  ));
 }
 
 function buildNpcFlags(campaign: Campaign, missionIndex: number): Record<string, boolean> {

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -110,6 +110,26 @@ export interface LabData {
 const [activeLab, setActiveLab] = createSignal<LabData | null>(null);
 const [activeShop, setActiveShop] = createSignal<ShopData | null>(null);
 const [popupMessage, setPopupMessage] = createSignal<PopupMessage | null>(null);
+const popupQueue: PopupMessage[] = [];
+
+function clearCurrentPopup(): void {
+  const next = popupQueue.shift();
+  if (next) {
+    setPopupMessage(next);
+    setTimeout(clearCurrentPopup, 3000);
+  } else {
+    setPopupMessage(null);
+  }
+}
+
+function showPopup(popup: PopupMessage): void {
+  if (popupMessage()) {
+    popupQueue.push(popup);
+  } else {
+    setPopupMessage(popup);
+    setTimeout(clearCurrentPopup, 3000);
+  }
+}
 
 function incrementClickAttack(amount = 1): void {
   setPlayerStats((prev) => prev ? { ...prev, clickAttack: prev.clickAttack + amount } : prev);
@@ -171,7 +191,7 @@ export {
   setPilotZoidIds,
   setPlayerDamageEvents,
   setPlayerStats,
-  setPopupMessage,
+  showPopup,
   setRewardEvents,
   setShowClickHint,
   showClickHint,

--- a/src/store/inventoryStore.ts
+++ b/src/store/inventoryStore.ts
@@ -4,7 +4,7 @@ import { type ConsumableItem, ItemType } from '../item';
 import { ITEMS } from '../item';
 import { Currency } from '../models/Currency';
 import { PopupMessage, PopupType } from '../models/PopupMessage';
-import { setPopupMessage } from './gameStore';
+import { showPopup } from './gameStore';
 import { addCurrency, getCurrency } from './walletStore';
 
 const [inventory, setInventory] = createSignal<Record<string, number>>({});
@@ -28,13 +28,12 @@ function addItem(itemId: string, amount: number, unique = false): void {
     return;
   }
   if (getItemCount(itemId) === 0) {
-    setPopupMessage(new PopupMessage(
+    showPopup(new PopupMessage(
       t(`items:${itemId}.name`),
       t('ui:new_item'),
       PopupType.Item,
       `images/items/${itemId}.png`
     ));
-    setTimeout(() => setPopupMessage(null), 3000);
   }
   setInventory((prev) => ({ ...prev, [itemId]: (prev[itemId] ?? 0) + amount }));
 }

--- a/src/ui/CampaignPanel.tsx
+++ b/src/ui/CampaignPanel.tsx
@@ -1,4 +1,4 @@
-import { For, Show, type Component } from 'solid-js';
+import { createEffect, For, on, Show, type Component } from 'solid-js';
 import { CAMPAIGNS } from '../campaign/campaigns';
 import type { Campaign } from '../campaign/Campaign';
 import { t } from '../i18n';
@@ -25,16 +25,29 @@ function currentMissionInfo(campaign: Campaign): MissionInfo | undefined {
 
 const CampaignEntry: Component<{ campaign: Campaign }> = (props) => {
   const mission = () => currentMissionInfo(props.campaign);
+  let missionRef: HTMLDivElement | undefined;
+
+  createEffect(on(
+    () => getCampaignState(props.campaign.id).currentMission,
+    (current, prev) => {
+      if (prev && prev !== current && missionRef) {
+        missionRef.classList.remove('campaign-mission-transition');
+        void missionRef.offsetWidth;
+        missionRef.classList.add('campaign-mission-transition');
+      }
+    }
+  ));
+
   return (
     <div class="campaign-entry campaign-active">
       <div class="campaign-header">
         <span class="campaign-name">{t(`campaigns:${props.campaign.id}.name`)}</span>
       </div>
       <Show when={mission()}>
-        {(m) => <>
+        {(m) => <div ref={missionRef} class="campaign-mission-content">
           <div class="campaign-mission-name">{m().name}</div>
           <div class="campaign-mission-hint">{m().description}</div>
-        </>}
+        </div>}
       </Show>
     </div>
   );

--- a/src/ui/campaign.css
+++ b/src/ui/campaign.css
@@ -54,6 +54,12 @@
   background: rgb(0 212 255 / 5%);
 }
 
+.campaign-mission-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
 .campaign-mission-name {
   color: #00d4ff;
   font-size: 0.8rem;
@@ -64,6 +70,29 @@
   color: #fff;
   font-size: 0.75rem;
   font-style: italic;
+}
+
+.campaign-mission-transition {
+  animation: mission-change 1.2s ease-out;
+}
+
+@keyframes mission-change {
+  0% {
+    opacity: 0;
+    text-shadow: 0 0 8px #00d4ff;
+    transform: translateY(-4px);
+  }
+
+  30% {
+    opacity: 1;
+    text-shadow: 0 0 12px #00d4ff, 0 0 24px rgb(0 212 255 / 40%);
+  }
+
+  100% {
+    opacity: 1;
+    text-shadow: none;
+    transform: translateY(0);
+  }
 }
 
 .campaign-description {


### PR DESCRIPTION
## Summary
- Show a blue "mission completed" popup when a mission finishes, with the completed mission name
- Add a popup queue so multiple popups (mission complete + reward) show sequentially instead of overwriting each other
- Add panel animation (fade-in with cyan glow) when the active mission changes in the campaign panel
- Fix panel animation triggering incorrectly on NPC flag updates by comparing mission IDs
- Use `keyed` on popup `<Show>` to re-mount elements and restart CSS animations between queued popups

Closes #82

## Test plan
- [x] Complete a mission → blue popup "Mission Completed!" appears with mission name
- [x] Complete a mission that triggers a reward (item/cutscene) → both popups show in sequence
- [x] Talk to NPCs without completing a mission → no false animation in campaign panel
- [x] Campaign panel shows fade-in animation when mission actually changes