### PR TITLE
Fix battle panel constant height (#103)

### DIFF
--- a/src/dungeon/dungeon.css
+++ b/src/dungeon/dungeon.css
@@ -6,6 +6,7 @@
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+  height: 51vh;
   padding: 0.8rem;
   width: 100%;
 }
@@ -25,6 +26,8 @@
 
 .dungeon-graph-container {
   border-radius: 8px;
+  flex: 1;
+  min-height: 0;
   overflow: hidden;
   position: relative;
   width: 100%;
@@ -67,6 +70,7 @@
 .dungeon-layers {
   display: flex;
   flex-direction: row;
+  height: 100%;
   justify-content: space-around;
   padding: 1rem 0.5rem;
   width: 100%;
@@ -78,6 +82,7 @@
   flex: 1;
   flex-direction: column;
   gap: 0.8rem;
+  justify-content: center;
 }
 
 /* Node styles */
@@ -271,8 +276,8 @@
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
+  height: 51vh;
   justify-content: center;
-  min-height: 200px;
   padding: 1.5rem;
   width: 100%;
 }
@@ -343,8 +348,8 @@
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
+  height: 51vh;
   justify-content: center;
-  min-height: 200px;
   padding: 1.5rem;
   width: 100%;
 }
@@ -483,5 +488,29 @@
   to {
     opacity: 1;
     transform: translateY(0);
+  }
+}
+
+@media (width <= 768px) {
+  .dungeon-event-screen,
+  .dungeon-map-screen,
+  .dungeon-supply-screen {
+    height: 40vh;
+  }
+}
+
+@media (width <= 768px) and (orientation: landscape) {
+  .dungeon-event-screen,
+  .dungeon-map-screen,
+  .dungeon-supply-screen {
+    height: 35vh;
+  }
+}
+
+@media (width <= 480px) {
+  .dungeon-event-screen,
+  .dungeon-map-screen,
+  .dungeon-supply-screen {
+    height: 35vh;
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -286,11 +286,8 @@ body {
   }
 
   .battle-screen {
+    height: 40vh;
     padding: 0.5rem;
-  }
-
-  .battle-area {
-    height: 35vh;
   }
 
   .defeat-content button {
@@ -317,8 +314,8 @@ body {
 }
 
 @media (width <= 768px) and (orientation: landscape) {
-  .battle-area {
-    height: 30vh;
+  .battle-screen {
+    height: 35vh;
   }
 }
 
@@ -338,6 +335,7 @@ body {
 
   .battle-screen {
     border-radius: 8px;
+    height: 35vh;
     padding: 0.3rem;
   }
 

--- a/src/ui/battle.css
+++ b/src/ui/battle.css
@@ -2,6 +2,9 @@
   background: #16213e;
   border: 2px solid #0f3460;
   border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  height: 51vh;
   padding: 0.8rem;
   position: relative;
   width: 100%;
@@ -9,9 +12,11 @@
 
 .enemy-section {
   display: flex;
+  flex: 1;
   flex-direction: column;
   align-items: center;
   gap: 0.5rem;
+  min-height: 0;
 }
 
 .enemy-name {
@@ -59,8 +64,9 @@
   border-radius: 8px;
   cursor: pointer;
   display: flex;
-  height: 40vh;
+  flex: 1;
   justify-content: center;
+  min-height: 0;
   margin-top: 1rem;
   overflow: hidden;
   position: relative;


### PR DESCRIPTION
## Summary
- Set a fixed height on `.battle-screen` (51vh desktop, 40vh tablet, 35vh mobile/landscape) so the panel never changes size when switching between battle, idle, dungeon, and pilot screens
- Replace `.battle-area` fixed `height: 40vh` with `flex: 1` so it adapts to the remaining space inside the container
- Apply the same fixed height to `.dungeon-map-screen`, `.dungeon-event-screen`, and `.dungeon-supply-screen` to prevent layout jumps during sorties
- Center dungeon nodes vertically so they stay centered as layers are completed

Closes #103

## Test plan
- [x] Navigate between routes and cities — panel height should not change
- [x] Run a full sortie (dungeon map → battle → event → supply → boss) — no layout jumps
- [x] Test on tablet and mobile breakpoints
- [ ] Test landscape orientation