### PR TITLE
Add dungeon map move animation (#52)

### DIFF
--- a/src/dungeon/DungeonGraph.ts
+++ b/src/dungeon/DungeonGraph.ts
@@ -2,6 +2,7 @@ export const SortieNodeType = {
   Boss: 'boss',
   Combat: 'combat',
   Elite: 'elite',
+  Entry: 'entry',
   Event: 'event',
   Supply: 'supply',
 } as const;

--- a/src/dungeon/DungeonMapScreen.test.ts
+++ b/src/dungeon/DungeonMapScreen.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { DungeonEvent, DungeonEventChoice, HealOutcome } from './DungeonEventOutcome';
+import { DungeonSortieEvent } from './DungeonSortieEvent';
+import { ENTRY_NODE_ID } from './generateSortie';
+import {
+  advanceLayer,
+  dungeonRun,
+  endDungeon,
+  isLayerAdvancing,
+  markNodeCompleted,
+  setIsLayerAdvancing,
+  startSortie,
+} from './dungeonStore';
+
+const DUMMY_EVENT = new DungeonEvent('e1', 'test', [new DungeonEventChoice('ok', new HealOutcome('heal', 10))]);
+
+const DUMMY_SORTIE = new DungeonSortieEvent({
+  baseReward: { magnis: 100 },
+  bossTiers: [{ pilots: ['bandit1'] }],
+  eliteEnemies: [],
+  enemies: [{ zoidData: { id: 'gator', level: 1 } }],
+  entryCost: 0,
+  eventPool: [DUMMY_EVENT],
+  id: 'test_sortie',
+  layers: 3,
+  nodesPerLayer: [2, 3],
+  supplyOptions: [],
+});
+
+describe('Dungeon layer advance animation', () => {
+  afterEach(() => {
+    if (dungeonRun()) { endDungeon(); }
+    setIsLayerAdvancing(false);
+  });
+
+  it('starts at depth 1 with entry node completed', () => {
+    startSortie(DUMMY_SORTIE, 100, 100);
+    const run = dungeonRun()!;
+    expect(run.currentDepth).toBe(1);
+    expect(run.nodeResults[ENTRY_NODE_ID]).toBe('completed');
+    expect(run.graph[0].nodes[0].id).toBe(ENTRY_NODE_ID);
+  });
+
+  it('entry node connects to all first-layer nodes', () => {
+    startSortie(DUMMY_SORTIE, 100, 100);
+    const run = dungeonRun()!;
+    const entryNode = run.graph[0].nodes[0];
+    const firstLayerNodes = run.graph[1].nodes;
+    for (const node of firstLayerNodes) {
+      expect(entryNode.connectsTo).toContain(node.id);
+    }
+  });
+
+  it('advanceLayer increments depth without setting isLayerAdvancing', () => {
+    startSortie(DUMMY_SORTIE, 100, 100);
+    const run = dungeonRun()!;
+    markNodeCompleted(run.graph[1].nodes[0].id);
+    advanceLayer();
+
+    expect(isLayerAdvancing()).toBe(false);
+    expect(dungeonRun()!.currentDepth).toBe(2);
+  });
+
+  it('visibleLayers includes previous layer', () => {
+    startSortie(DUMMY_SORTIE, 100, 100);
+    const run = dungeonRun()!;
+
+    const visible = run.graph.slice(Math.max(0, run.currentDepth - 1));
+    expect(visible[0].depth).toBe(0);
+    expect(visible[1].depth).toBe(1);
+  });
+
+  it('endDungeon clears isLayerAdvancing', () => {
+    startSortie(DUMMY_SORTIE, 100, 100);
+    setIsLayerAdvancing(true);
+    expect(isLayerAdvancing()).toBe(true);
+
+    endDungeon();
+    expect(isLayerAdvancing()).toBe(false);
+  });
+});

--- a/src/dungeon/DungeonMapScreen.tsx
+++ b/src/dungeon/DungeonMapScreen.tsx
@@ -4,7 +4,7 @@ import { getPilotImage } from '../models/Pilot';
 import { playerStats } from '../store/gameStore';
 import { landmarkBackground } from '../store/landmarkStore';
 import { type SortieNode, SortieNodeType } from './DungeonGraph';
-import { type DungeonRunState, dungeonRun } from './dungeonStore';
+import { type DungeonRunState, dungeonRun, isLayerAdvancing, setIsLayerAdvancing } from './dungeonStore';
 import './dungeon.css';
 
 interface Props {
@@ -16,12 +16,14 @@ const NODE_ICONS: Record<SortieNodeType, string> = {
   [SortieNodeType.Boss]: '\u{1F480}',
   [SortieNodeType.Combat]: '\u{1F4A5}',
   [SortieNodeType.Elite]: '\u{2B50}',
+  [SortieNodeType.Entry]: '\u{1F6AA}',
   [SortieNodeType.Event]: '\u{2753}',
   [SortieNodeType.Supply]: '\u{1F4E6}',
 };
 
 const DungeonMapScreen: Component<Props> = (props) => {
-  let containerRef: HTMLDivElement | undefined;
+  let layersRef: HTMLDivElement | undefined;
+  let markerRef: HTMLDivElement | undefined;
   let svgRef: SVGSVGElement | undefined;
 
   const run = createMemo(() => dungeonRun());
@@ -29,7 +31,14 @@ const DungeonMapScreen: Component<Props> = (props) => {
   const visibleLayers = createMemo(() => {
     const r = run();
     if (!r) {return [];}
-    return r.graph.slice(r.currentDepth);
+    return r.graph.slice(Math.max(0, r.currentDepth - 1));
+  });
+
+  const lastCompletedNodeId = createMemo(() => {
+    const r = run();
+    if (!r) {return null;}
+    const prevLayer = r.graph[r.currentDepth - 1];
+    return prevLayer?.nodes.find((n) => r.nodeResults[n.id] === 'completed')?.id ?? null;
   });
 
   const possibleBosses = createMemo(() => {
@@ -47,6 +56,7 @@ const DungeonMapScreen: Component<Props> = (props) => {
   });
 
   function isNodeSelectable(node: SortieNode, state: DungeonRunState): boolean {
+    if (isLayerAdvancing()) {return false;}
     if (state.nodeResults[node.id]) {return false;}
     if (state.currentDepth === 0) {return true;}
     const prevLayer = state.graph[state.currentDepth - 1];
@@ -55,7 +65,7 @@ const DungeonMapScreen: Component<Props> = (props) => {
   }
 
   function drawConnections(): void {
-    if (!svgRef || !containerRef) {return;}
+    if (!svgRef || !layersRef) {return;}
     const r = run();
     if (!r) {return;}
 
@@ -63,21 +73,21 @@ const DungeonMapScreen: Component<Props> = (props) => {
       svgRef.removeChild(svgRef.firstChild);
     }
 
-    const containerRect = containerRef.getBoundingClientRect();
+    const containerRect = layersRef.getBoundingClientRect();
     const layers = visibleLayers();
 
     for (let i = 0; i < layers.length - 1; i++) {
       for (const node of layers[i].nodes) {
-        const fromEl = containerRef.querySelector(`[data-node-id="${node.id}"]`);
+        const fromEl = layersRef.querySelector(`[data-node-id="${node.id}"]`);
         if (!fromEl) {continue;}
         const fromRect = fromEl.getBoundingClientRect();
 
         for (const targetId of node.connectsTo) {
-          const toEl = containerRef.querySelector(`[data-node-id="${targetId}"]`);
+          const toEl = layersRef.querySelector(`[data-node-id="${targetId}"]`);
           if (!toEl) {continue;}
           const toRect = toEl.getBoundingClientRect();
 
-          const isFirstLayer = i === 0;
+          const isFirstLayer = layers[i].depth === r.currentDepth;
 
           const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
           line.setAttribute('x1', String(fromRect.left + fromRect.width / 2 - containerRect.left));
@@ -91,9 +101,64 @@ const DungeonMapScreen: Component<Props> = (props) => {
     }
   }
 
+  function positionMarkerOn(nodeId: string, animate: boolean): void {
+    if (!markerRef || !layersRef) {return;}
+    const nodeEl = layersRef.querySelector(`[data-node-id="${nodeId}"]`);
+    if (!nodeEl) {return;}
+
+    const layersRect = layersRef.getBoundingClientRect();
+    const nodeRect = nodeEl.getBoundingClientRect();
+
+    markerRef.style.transition = animate ? 'left 0.3s ease-out, top 0.3s ease-out' : 'none';
+    markerRef.style.left = `${nodeRect.left + nodeRect.width / 2 - layersRect.left}px`;
+    markerRef.style.top = `${nodeRect.top + nodeRect.height / 2 - layersRect.top}px`;
+  }
+
+  function handleNodeSelect(nodeId: string): void {
+    const el = layersRef;
+    if (!el || !markerRef) {
+      props.onNodeSelect(nodeId);
+      return;
+    }
+
+    setIsLayerAdvancing(true);
+
+    positionMarkerOn(nodeId, true);
+
+    const onMarkerEnd = (): void => {
+      markerRef!.removeEventListener('transitionend', onMarkerEnd);
+
+      const layerWidth = el.offsetWidth / visibleLayers().length;
+      el.style.transition = 'transform 0.5s ease-out';
+      el.style.transform = `translateX(-${layerWidth}px)`;
+
+      const onSlideEnd = (): void => {
+        el.removeEventListener('transitionend', onSlideEnd);
+        setIsLayerAdvancing(false);
+        props.onNodeSelect(nodeId);
+      };
+      el.addEventListener('transitionend', onSlideEnd, { once: true });
+    };
+    markerRef.addEventListener('transitionend', onMarkerEnd, { once: true });
+  }
+
   createEffect(() => {
     visibleLayers();
-    requestAnimationFrame(() => requestAnimationFrame(drawConnections));
+    if (!isLayerAdvancing()) {
+      const el = layersRef;
+      if (el) {
+        el.style.width = '';
+        el.style.transform = '';
+        el.style.transition = 'none';
+      }
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          drawConnections();
+          const nodeId = lastCompletedNodeId();
+          if (nodeId) {positionMarkerOn(nodeId, false);}
+        });
+      });
+    }
   });
 
   return (
@@ -102,35 +167,37 @@ const DungeonMapScreen: Component<Props> = (props) => {
       <p class="dungeon-subtitle">{t('ui:select_path')}</p>
       <div
         class="dungeon-graph-container"
-        ref={containerRef}
         style={{ 'background-image': `url('${landmarkBackground()}')`, 'background-size': 'cover' }}
       >
-        <svg class="dungeon-connections" ref={svgRef} />
-        <div class="dungeon-layers">
+        <div class="dungeon-layers" ref={layersRef}>
+          <svg class="dungeon-connections" ref={svgRef} />
+          <div class="player-marker" ref={markerRef} />
           <For each={visibleLayers()}>
-            {(layer) => (
-              <div class="dungeon-layer">
-                <For each={layer.nodes}>
-                  {(node) => {
-                    const r = run()!;
-                    const isCompleted = () => r.nodeResults[node.id] === 'completed';
-                    const isCurrent = () => layer.depth === r.currentDepth;
-                    const selectable = () => isCurrent() && isNodeSelectable(node, r);
-                    return (
-                      <button
-                        class={`dungeon-node dungeon-node-${node.type}${isCompleted() ? ' completed' : ''}${selectable() ? ' selectable' : ''}`}
-                        data-node-id={node.id}
-                        disabled={!selectable()}
-                        onClick={() => props.onNodeSelect(node.id)}
-                        title={node.type}
-                      >
-                        <span class="node-icon">{NODE_ICONS[node.type]}</span>
-                      </button>
-                    );
-                  }}
-                </For>
-              </div>
-            )}
+            {(layer) => {
+              const r = run()!;
+              const isCurrent = () => layer.depth === r.currentDepth;
+              return (
+                <div class="dungeon-layer">
+                  <For each={layer.nodes}>
+                    {(node) => {
+                      const isCompleted = () => r.nodeResults[node.id] === 'completed';
+                      const selectable = () => isCurrent() && isNodeSelectable(node, r);
+                      return (
+                        <button
+                          class={`dungeon-node dungeon-node-${node.type}${isCompleted() ? ' completed' : ''}${selectable() ? ' selectable' : ''}`}
+                          data-node-id={node.id}
+                          disabled={!selectable()}
+                          onClick={() => handleNodeSelect(node.id)}
+                          title={node.type}
+                        >
+                          <span class="node-icon">{NODE_ICONS[node.type]}</span>
+                        </button>
+                      );
+                    }}
+                  </For>
+                </div>
+              );
+            }}
           </For>
         </div>
         <div class="dungeon-boss-previews">

--- a/src/dungeon/dungeon.css
+++ b/src/dungeon/dungeon.css
@@ -72,7 +72,10 @@
   flex-direction: row;
   height: 100%;
   justify-content: space-around;
+  left: 0;
   padding: 1rem 0.5rem;
+  position: absolute;
+  top: 0;
   width: 100%;
 }
 
@@ -83,6 +86,31 @@
   flex-direction: column;
   gap: 0.8rem;
   justify-content: center;
+}
+
+/* Player marker */
+.player-marker {
+  animation: marker-pulse 1.5s ease-in-out infinite;
+  background: #e94560;
+  border: 2px solid #fff;
+  border-radius: 50%;
+  box-shadow: 0 0 8px rgb(233 69 96 / 60%);
+  height: 14px;
+  pointer-events: none;
+  position: absolute;
+  transform: translate(-50%, -50%);
+  width: 14px;
+  z-index: 2;
+}
+
+@keyframes marker-pulse {
+  0%, 100% {
+    box-shadow: 0 0 8px rgb(233 69 96 / 60%);
+  }
+
+  50% {
+    box-shadow: 0 0 16px rgb(233 69 96 / 90%);
+  }
 }
 
 /* Node styles */
@@ -122,6 +150,10 @@
 
 .dungeon-node-boss {
   border-color: #9b59b6;
+}
+
+.dungeon-node-entry.completed {
+  border-color: #888;
 }
 
 .dungeon-node-boss.selectable {

--- a/src/dungeon/dungeonStore.ts
+++ b/src/dungeon/dungeonStore.ts
@@ -10,7 +10,7 @@ import { SortieNodeType } from './DungeonGraph';
 import type { SortieLayer, SortieNode } from './DungeonGraph';
 import { SupplyCostType, SupplyType } from './DungeonSupply';
 import type { SupplyOption } from './DungeonSupply';
-import { generateSortie } from './generateSortie';
+import { ENTRY_NODE_ID, generateSortie } from './generateSortie';
 
 export const DungeonPhase = {
   Boss: 'boss',
@@ -34,6 +34,7 @@ export interface DungeonRunState {
 
 const [dungeonPhase, setDungeonPhase] = createSignal<DungeonPhase>(DungeonPhase.Map);
 const [dungeonRun, setDungeonRun] = createSignal<DungeonRunState | null>(null);
+const [isLayerAdvancing, setIsLayerAdvancing] = createSignal(false);
 
 const isDungeonActive = createMemo(() => dungeonRun() !== null);
 
@@ -108,6 +109,7 @@ function changePlayerHealth(delta: number, minHealth = 0): void {
 }
 
 function endDungeon(): void {
+  setIsLayerAdvancing(false);
   resetBuffs();
   setDungeonRun(null);
   setDungeonPhase(DungeonPhase.Map);
@@ -153,10 +155,10 @@ function startSortie(config: DungeonSortieEvent, playerHealth: number, playerMax
   setDungeonRun({
     bossPilot: config.resolveBoss(),
     config,
-    currentDepth: 0,
+    currentDepth: 1,
     currentNodeId: null,
     graph,
-    nodeResults: {},
+    nodeResults: { [ENTRY_NODE_ID]: 'completed' },
     playerHealth,
     playerMaxHealth,
   });
@@ -175,9 +177,11 @@ export {
   findNode,
   getPlayerHealth,
   isDungeonActive,
+  isLayerAdvancing,
   isPlayerDead,
   markNodeCompleted,
   selectNode,
   setDungeonPhase,
+  setIsLayerAdvancing,
   startSortie,
 };

--- a/src/dungeon/generateSortie.ts
+++ b/src/dungeon/generateSortie.ts
@@ -5,22 +5,30 @@ interface GenerateOptions {
   nodesPerLayer: [number, number];
 }
 
+export const ENTRY_NODE_ID = 'entry';
+
 export function generateSortie({ layers, nodesPerLayer }: GenerateOptions): SortieLayer[] {
   const result: SortieLayer[] = [];
 
-  for (let depth = 0; depth < layers; depth++) {
+  result.push({
+    depth: 0,
+    nodes: [{ connectsTo: [], eventSeed: 0, id: ENTRY_NODE_ID, type: SortieNodeType.Entry }],
+  });
+
+  for (let i = 0; i < layers; i++) {
+    const depth = i + 1;
     const count = randomBetween(nodesPerLayer[0], nodesPerLayer[1]);
-    const nodes: SortieNode[] = Array.from({ length: count }, (_, i) => ({
+    const nodes: SortieNode[] = Array.from({ length: count }, (_, j) => ({
       connectsTo: [],
       eventSeed: randomBetween(1, 100),
-      id: `node_${depth}_${i}`,
-      type: pickNodeType(depth, layers),
+      id: `node_${depth}_${j}`,
+      type: pickNodeType(i, layers),
     }));
     result.push({ depth, nodes });
   }
 
   result.push({
-    depth: layers,
+    depth: layers + 1,
     nodes: [{ connectsTo: [], eventSeed: 0, id: 'boss', type: SortieNodeType.Boss }],
   });
 


### PR DESCRIPTION
## Summary
- Add slide animation when selecting a dungeon node: player marker moves to the selected node, then the map slides left before transitioning to battle/event/supply
- Add entry node (🚪) as layer 0 that connects to all first-layer nodes, so every selection has the slide animation
- Player marker (pulsing red dot) positioned over the last completed node, moves along connection paths on selection
- Previous layer always visible in the map, showing where the player came from

## Test plan
- [x] Enter a dungeon — entry node visible on the left, first layer nodes selectable
- [x] Select a node — marker moves to it, then map slides left, then battle/event/supply starts
- [x] Complete battle and return to map — marker on last completed node, previous layer visible
- [x] Repeat through multiple layers — animation consistent each time
- [x] Retreat mid-dungeon — no broken animation state
- [x] Run `npx vitest run` — all 278 tests pass

Closes #52