### PR TITLE
Improve world map navigation and hover labels (#115, #72)

### DIFF
--- a/src/map/WorldMap.css
+++ b/src/map/WorldMap.css
@@ -7,6 +7,26 @@
   padding: 0.5rem;
 }
 
+.map-svg-container {
+  position: relative;
+}
+
+.map-hover-label {
+  background: rgb(0 0 0 / 70%);
+  border-radius: 4px;
+  color: #fff;
+  font-size: 0.85rem;
+  font-weight: bold;
+  left: 50%;
+  padding: 0.2rem 0.6rem;
+  pointer-events: none;
+  position: absolute;
+  top: 0.4rem;
+  transform: translateX(-50%);
+  white-space: nowrap;
+  z-index: 1;
+}
+
 .world-map-title {
   color: #00d4ff;
   cursor: pointer;

--- a/src/map/WorldMap.css
+++ b/src/map/WorldMap.css
@@ -69,9 +69,12 @@
 }
 
 .map-node-label {
-  fill: #000;
+  fill: #fff;
   font-weight: bold;
+  paint-order: stroke;
   pointer-events: none;
+  stroke: #000;
+  stroke-width: 3px;
   text-anchor: middle;
 }
 
@@ -102,6 +105,16 @@
   filter: drop-shadow(0 0 4px #00d4ff);
   image-rendering: pixelated;
   pointer-events: none;
+}
+
+@media (hover: none) {
+  .map-node:hover {
+    filter: none;
+  }
+
+  .map-route:hover {
+    filter: none;
+  }
 }
 
 @keyframes map-pulse {

--- a/src/map/WorldMap.tsx
+++ b/src/map/WorldMap.tsx
@@ -1,4 +1,4 @@
-import { For, Show, type Component } from 'solid-js';
+import { createSignal, For, Show, type Component } from 'solid-js';
 import { t } from '../i18n';
 import type { Landmark, Route } from '../landmark';
 import { LandmarkType, getCity, getDungeon, isLandmarkUnlocked } from '../landmark';
@@ -28,6 +28,8 @@ const WorldMap: Component<WorldMapProps> = (props) => {
     };
   }
 
+  const [hoveredLandmark, setHoveredLandmark] = createSignal<Landmark | null>(null);
+
   function handleLandmarkClick(landmark: Landmark) {
     props.onLocationChange(landmark);
   }
@@ -40,159 +42,174 @@ const WorldMap: Component<WorldMapProps> = (props) => {
       </h2>
       <Show when={mapOpen()}>
         <p class="world-map-subtitle">{t(`locations:${currentRegion().id}_subtitle`)}</p>
-        <svg
-          viewBox={`${currentRegion().viewBox.x} ${currentRegion().viewBox.y} ${currentRegion().viewBox.w} ${currentRegion().viewBox.h}`}
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <image
-            href={currentRegion().image}
-            width={currentRegion().imageSize.w}
-            height={currentRegion().imageSize.h}
-          />
-          {(() => {
-            const scale = currentRegion().viewBox.w / currentRegion().imageSize.w;
-            const cityRadius = 20 * scale;
-            const fontSize = 28 * scale;
-            const minHitSize = 24;
-            const routeHitWidth = Math.max(15 * scale, minHitSize);
-            const routeStrokeWidth = 15 * scale;
-            const spriteSize = currentRegion().viewBox.w * 0.06;
-            const strokeWidth = 3 * scale;
-            const cityHitRadius = Math.max(cityRadius, minHitSize / 2);
+        <div class="map-svg-container">
+          <svg
+            viewBox={`${currentRegion().viewBox.x} ${currentRegion().viewBox.y} ${currentRegion().viewBox.w} ${currentRegion().viewBox.h}`}
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <image
+              href={currentRegion().image}
+              width={currentRegion().imageSize.w}
+              height={currentRegion().imageSize.h}
+            />
+            {(() => {
+              const scale = currentRegion().viewBox.w / currentRegion().imageSize.w;
+              const cityRadius = 18 * scale;
+              const fontSize = 28 * scale;
+              const minHitSize = 24;
+              const routeHitWidth = Math.max(15 * scale, minHitSize);
+              const routeStrokeWidth = 15 * scale;
+              const spriteSize = currentRegion().viewBox.w * 0.06;
+              const strokeWidth = 3 * scale;
+              const cityHitRadius = Math.max(cityRadius, minHitSize / 4);
 
-            const playerPos = () => {
-              const landmark = currentLandmark();
-              if (landmark.type === LandmarkType.Route) {
-                const route = landmark as Route;
-                const from = cityPosition(route.connects[0]);
-                const to = cityPosition(route.connects[1]);
-                return { x: (from.x + to.x) / 2, y: (from.y + to.y) / 2 };
-              }
-              return cityPosition(landmark.id);
-            };
+              const playerPos = () => {
+                const landmark = currentLandmark();
+                if (landmark.type === LandmarkType.Route) {
+                  const route = landmark as Route;
+                  const from = cityPosition(route.connects[0]);
+                  const to = cityPosition(route.connects[1]);
+                  return { x: (from.x + to.x) / 2, y: (from.y + to.y) / 2 };
+                }
+                return cityPosition(landmark.id);
+              };
 
-            return (
-              <>
-                <For each={routesForRegion(currentRegion())}>
-                  {(route) => {
-                    const from = () => cityPosition(route.connects[0]);
-                    const to = () => cityPosition(route.connects[1]);
-                    const isCurrent = () => currentLandmark().id === route.id;
-                    const locked = () => !isLandmarkUnlocked(route);
+              return (
+                <>
+                  <For each={routesForRegion(currentRegion())}>
+                    {(route) => {
+                      const from = () => cityPosition(route.connects[0]);
+                      const to = () => cityPosition(route.connects[1]);
+                      const isCurrent = () => currentLandmark().id === route.id;
+                      const locked = () => !isLandmarkUnlocked(route);
 
-                    return (
-                      <g
-                        class={`map-route ${isCurrent() ? 'map-route--current' : ''} ${locked() ? 'map-route--locked' : ''}`}
-                        onClick={() => handleLandmarkClick(route)}
-                      >
-                        <line
-                          x1={from().x}
-                          y1={from().y}
-                          x2={to().x}
-                          y2={to().y}
-                          stroke="transparent"
-                          stroke-width={routeHitWidth}
-                          stroke-linecap="round"
-                        />
-                        <line
-                          x1={from().x}
-                          y1={from().y}
-                          x2={to().x}
-                          y2={to().y}
-                          stroke="#000"
-                          stroke-width={routeStrokeWidth * 2}
-                          stroke-linecap="round"
-                        />
-                        <line
-                          x1={from().x}
-                          y1={from().y}
-                          x2={to().x}
-                          y2={to().y}
-                          stroke={locked() ? '#444' : isCurrent() ? '#00d4ff' : '#ffc107'}
-                          stroke-width={routeStrokeWidth}
-                          stroke-linecap="round"
-                        />
-                      </g>
-                    );
-                  }}
-                </For>
-                <For each={citiesForRegion(currentRegion())}>
-                  {(city) => {
-                    const cx = () => (city.mapPosition.x / 100) * currentRegion().imageSize.w;
-                    const cy = () => (city.mapPosition.y / 100) * currentRegion().imageSize.h;
-                    const isCurrent = () => currentLandmark().id === city.id;
-                    const locked = () => !isLandmarkUnlocked(city);
-
-                    return (
-                      <g
-                        class={`map-node ${isCurrent() ? 'map-node--current' : ''} ${locked() ? 'map-node--locked' : ''}`}
-                        onClick={() => handleLandmarkClick(city)}
-                      >
-                        <circle cx={cx()} cy={cy()} r={cityHitRadius} fill="transparent" />
-                        <circle
-                          cx={cx()}
-                          cy={cy()}
-                          r={cityRadius}
-                          fill={locked() ? '#444' : isCurrent() ? '#3b82f6' : '#f97316'}
-                          stroke={locked() ? '#666' : isCurrent() ? '#fff' : '#fff'}
-                          stroke-width={strokeWidth}
-                        />
-                        <text
-                          class="map-node-label"
-                          x={cx()}
-                          y={cy() - cityRadius - 5 * scale}
-                          font-size={`${fontSize}`}
+                      return (
+                        <g
+                          class={`map-route ${isCurrent() ? 'map-route--current' : ''} ${locked() ? 'map-route--locked' : ''}`}
+                          onClick={() => handleLandmarkClick(route)}
+                          onMouseEnter={() => setHoveredLandmark(route)}
+                          onMouseLeave={() => setHoveredLandmark(null)}
                         >
-                          {t(`locations:${city.id}`).split(' ').map((w) => w[0]).join('')}
-                        </text>
-                      </g>
-                    );
-                  }}
-                </For>
-                <For each={dungeonsForRegion(currentRegion())}>
-                  {(dungeon) => {
-                    const cx = () => (dungeon.mapPosition.x / 100) * currentRegion().imageSize.w;
-                    const cy = () => (dungeon.mapPosition.y / 100) * currentRegion().imageSize.h;
-                    const isCurrent = () => currentLandmark().id === dungeon.id;
-                    const locked = () => !isLandmarkUnlocked(dungeon);
+                          <line
+                            x1={from().x}
+                            y1={from().y}
+                            x2={to().x}
+                            y2={to().y}
+                            stroke="transparent"
+                            stroke-width={routeHitWidth}
+                            stroke-linecap="round"
+                          />
+                          <line
+                            x1={from().x}
+                            y1={from().y}
+                            x2={to().x}
+                            y2={to().y}
+                            stroke="#000"
+                            stroke-width={routeStrokeWidth * 2}
+                            stroke-linecap="round"
+                          />
+                          <line
+                            x1={from().x}
+                            y1={from().y}
+                            x2={to().x}
+                            y2={to().y}
+                            stroke={locked() ? '#444' : isCurrent() ? '#00d4ff' : '#ffc107'}
+                            stroke-width={routeStrokeWidth}
+                            stroke-linecap="round"
+                          />
+                        </g>
+                      );
+                    }}
+                  </For>
+                  <For each={citiesForRegion(currentRegion())}>
+                    {(city) => {
+                      const cx = () => (city.mapPosition.x / 100) * currentRegion().imageSize.w;
+                      const cy = () => (city.mapPosition.y / 100) * currentRegion().imageSize.h;
+                      const isCurrent = () => currentLandmark().id === city.id;
+                      const locked = () => !isLandmarkUnlocked(city);
 
-                    return (
-                      <g
-                        class={`map-node ${isCurrent() ? 'map-node--current' : ''} ${locked() ? 'map-node--locked' : ''}`}
-                        onClick={() => handleLandmarkClick(dungeon)}
-                      >
-                        <circle cx={cx()} cy={cy()} r={cityHitRadius} fill="transparent" />
-                        <polygon
-                          points={`${cx()},${cy() - cityRadius} ${cx() - cityRadius},${cy() + cityRadius} ${cx() + cityRadius},${cy() + cityRadius}`}
-                          fill={locked() ? '#444' : isCurrent() ? '#3b82f6' : '#f97316'}
-                          stroke={locked() ? '#666' : isCurrent() ? '#fff' : '#fff'}
-                          stroke-width={strokeWidth}
-                          stroke-linejoin="round"
-                        />
-                        <text
-                          class="map-node-label"
-                          x={cx()}
-                          y={cy() - cityRadius - 5 * scale}
-                          font-size={`${fontSize}`}
+                      return (
+                        <g
+                          class={`map-node ${isCurrent() ? 'map-node--current' : ''} ${locked() ? 'map-node--locked' : ''}`}
+                          onClick={() => handleLandmarkClick(city)}
+                          onMouseEnter={() => setHoveredLandmark(city)}
+                          onMouseLeave={() => setHoveredLandmark(null)}
                         >
-                          {t(`locations:${dungeon.id}`).split(' ').map((w) => w[0]).join('')}
-                        </text>
-                      </g>
-                    );
-                  }}
-                </For>
-                <image
-                  class="map-player-sprite"
-                  href="images/characters/player_full.png"
-                  x={playerPos().x - spriteSize / 2}
-                  y={playerPos().y - spriteSize}
-                  width={spriteSize}
-                  height={spriteSize}
-                />
-              </>
-            );
-          })()}
-        </svg>
+                          <circle cx={cx()} cy={cy()} r={cityHitRadius} fill="transparent" />
+                          <circle
+                            cx={cx()}
+                            cy={cy()}
+                            r={cityRadius}
+                            fill={locked() ? '#444' : isCurrent() ? '#3b82f6' : '#f97316'}
+                            stroke={locked() ? '#666' : isCurrent() ? '#fff' : '#fff'}
+                            stroke-width={strokeWidth}
+                          />
+                          <text
+                            class="map-node-label"
+                            x={cx()}
+                            y={cy() - cityRadius - 5 * scale}
+                            font-size={`${fontSize}`}
+                          >
+                            {hoveredLandmark()?.id === city.id
+                              ? t(`locations:${city.id}`)
+                              : t(`locations:${city.id}`).split(' ').map((w) => w[0]).join('')}
+                          </text>
+                        </g>
+                      );
+                    }}
+                  </For>
+                  <For each={dungeonsForRegion(currentRegion())}>
+                    {(dungeon) => {
+                      const cx = () => (dungeon.mapPosition.x / 100) * currentRegion().imageSize.w;
+                      const cy = () => (dungeon.mapPosition.y / 100) * currentRegion().imageSize.h;
+                      const isCurrent = () => currentLandmark().id === dungeon.id;
+                      const locked = () => !isLandmarkUnlocked(dungeon);
+
+                      return (
+                        <g
+                          class={`map-node ${isCurrent() ? 'map-node--current' : ''} ${locked() ? 'map-node--locked' : ''}`}
+                          onClick={() => handleLandmarkClick(dungeon)}
+                          onMouseEnter={() => setHoveredLandmark(dungeon)}
+                          onMouseLeave={() => setHoveredLandmark(null)}
+                        >
+                          <circle cx={cx()} cy={cy()} r={cityHitRadius} fill="transparent" />
+                          <polygon
+                            points={`${cx()},${cy() - cityRadius} ${cx() - cityRadius},${cy() + cityRadius} ${cx() + cityRadius},${cy() + cityRadius}`}
+                            fill={locked() ? '#444' : isCurrent() ? '#3b82f6' : '#f97316'}
+                            stroke={locked() ? '#666' : isCurrent() ? '#fff' : '#fff'}
+                            stroke-width={strokeWidth}
+                            stroke-linejoin="round"
+                          />
+                          <text
+                            class="map-node-label"
+                            x={cx()}
+                            y={cy() - cityRadius - 5 * scale}
+                            font-size={`${fontSize}`}
+                          >
+                            {hoveredLandmark()?.id === dungeon.id
+                              ? t(`locations:${dungeon.id}`)
+                              : t(`locations:${dungeon.id}`).split(' ').map((w) => w[0]).join('')}
+                          </text>
+                        </g>
+                      );
+                    }}
+                  </For>
+                  <image
+                    class="map-player-sprite"
+                    href="images/characters/player_full.png"
+                    x={playerPos().x - spriteSize / 2}
+                    y={playerPos().y - spriteSize}
+                    width={spriteSize}
+                    height={spriteSize}
+                  />
+                </>
+              );
+            })()}
+          </svg>
+          <Show when={hoveredLandmark()}>
+            <div class="map-hover-label">{t(`locations:${hoveredLandmark()!.id}`)}</div>
+          </Show>
+        </div>
       </Show>
     </div>
   );

--- a/src/map/WorldMap.tsx
+++ b/src/map/WorldMap.tsx
@@ -51,11 +51,14 @@ const WorldMap: Component<WorldMapProps> = (props) => {
           />
           {(() => {
             const scale = currentRegion().viewBox.w / currentRegion().imageSize.w;
-            const cityRadius = 15 * scale;
+            const cityRadius = 20 * scale;
             const fontSize = 28 * scale;
+            const minHitSize = 24;
+            const routeHitWidth = Math.max(15 * scale, minHitSize);
             const routeStrokeWidth = 15 * scale;
             const spriteSize = currentRegion().viewBox.w * 0.06;
             const strokeWidth = 3 * scale;
+            const cityHitRadius = Math.max(cityRadius, minHitSize / 2);
 
             const playerPos = () => {
               const landmark = currentLandmark();
@@ -87,6 +90,24 @@ const WorldMap: Component<WorldMapProps> = (props) => {
                           y1={from().y}
                           x2={to().x}
                           y2={to().y}
+                          stroke="transparent"
+                          stroke-width={routeHitWidth}
+                          stroke-linecap="round"
+                        />
+                        <line
+                          x1={from().x}
+                          y1={from().y}
+                          x2={to().x}
+                          y2={to().y}
+                          stroke="#000"
+                          stroke-width={routeStrokeWidth * 2}
+                          stroke-linecap="round"
+                        />
+                        <line
+                          x1={from().x}
+                          y1={from().y}
+                          x2={to().x}
+                          y2={to().y}
                           stroke={locked() ? '#444' : isCurrent() ? '#00d4ff' : '#ffc107'}
                           stroke-width={routeStrokeWidth}
                           stroke-linecap="round"
@@ -107,6 +128,7 @@ const WorldMap: Component<WorldMapProps> = (props) => {
                         class={`map-node ${isCurrent() ? 'map-node--current' : ''} ${locked() ? 'map-node--locked' : ''}`}
                         onClick={() => handleLandmarkClick(city)}
                       >
+                        <circle cx={cx()} cy={cy()} r={cityHitRadius} fill="transparent" />
                         <circle
                           cx={cx()}
                           cy={cy()}
@@ -139,6 +161,7 @@ const WorldMap: Component<WorldMapProps> = (props) => {
                         class={`map-node ${isCurrent() ? 'map-node--current' : ''} ${locked() ? 'map-node--locked' : ''}`}
                         onClick={() => handleLandmarkClick(dungeon)}
                       >
+                        <circle cx={cx()} cy={cy()} r={cityHitRadius} fill="transparent" />
                         <polygon
                           points={`${cx()},${cy() - cityRadius} ${cx() - cityRadius},${cy() + cityRadius} ${cx() + cityRadius},${cy() + cityRadius}`}
                           fill={locked() ? '#444' : isCurrent() ? '#3b82f6' : '#f97316'}


### PR DESCRIPTION
## Summary
- Add invisible hit areas to routes, cities, and dungeons for better mobile tap targets (~30px instead of ~3.7px)
- Add black outline on route lines to make them look like interactive paths
- Show full landmark name on hover: initials swap to full name on cities/dungeons, overlay label at top of map for all landmarks
- Prevent sticky hover effects on touch devices with `@media (hover: none)`
- White outlined text labels for better contrast against route outlines

## Test plan
- [ ] Open on mobile emulation (375px) — routes should be tappable without browser zoom
- [ ] Hover over a city — initials change to full name, overlay label appears at top
- [ ] Hover over a route — overlay label appears at top of map
- [ ] Hover over a dungeon — same behavior as city
- [ ] Locked landmarks don't show hover effects
- [ ] Desktop hover glow effects still work
- [ ] Mobile (touch device) — no sticky hover effects

Closes #115
Closes #72