### PR TITLE
Save core preserver scan setup (#104)

### DIFF
--- a/src/game/Game.ts
+++ b/src/game/Game.ts
@@ -54,6 +54,7 @@ import { setCurrentLandmark } from '../store/landmarkStore';
 import { addZoidToArmy, partyMaxHealth, setParty } from '../store/partyStore';
 import { incrementPilotDefeats, loadStatistics } from '../store/statisticsStore';
 import { loadInventory } from '../store/inventoryStore';
+import { loadScanSetup } from '../store/scanStore';
 import { addCurrency, loadWallet } from '../store/walletStore';
 import { loadZoidData } from '../store/zoidDataStore';
 import { loadZoidResearch, updateZoidResearch } from '../store/zoidResearchStore';
@@ -375,6 +376,9 @@ export class Game {
       }
       if (data.playerStats) {
         setPlayerStats({ ...data.playerStats, attackMult: data.playerStats.attackMult ?? 1 });
+      }
+      if (data.scanSetup) {
+        loadScanSetup(data.scanSetup);
       }
       if (data.zoidResearch) {
         loadZoidResearch(data.zoidResearch);

--- a/src/game/Save.ts
+++ b/src/game/Save.ts
@@ -11,6 +11,8 @@ import { pilotDefeats, routeKills } from '../store/statisticsStore';
 import { inventory } from '../store/inventoryStore';
 import { wallet } from '../store/walletStore';
 import { zoidDataLog } from '../store/zoidDataStore';
+import type { ActiveScan } from '../store/scanStore';
+import { activeScan } from '../store/scanStore';
 import { zoidResearch } from '../store/zoidResearchStore';
 import { migrate } from './migrations';
 const SAVE_KEY = 'zoids-sleeper-save';
@@ -24,6 +26,7 @@ export interface SaveData {
   pilotDefeats?: Record<string, number>;
   playerStats?: PlayerStats;
   routeKills?: Record<string, number>;
+  scanSetup?: ActiveScan;
   version: string;
   wallet?: Record<string, number>;
   zoidData?: Record<string, number>;
@@ -108,6 +111,7 @@ export class Save {
       pilotDefeats: pilotDefeats(),
       playerStats: playerStats() ?? undefined,
       routeKills: routeKills(),
+      scanSetup: activeScan() ?? undefined,
       wallet: wallet(),
       zoidData: zoidDataLog(),
       zoidResearch: zoidResearch(),

--- a/src/store/scanStore.test.ts
+++ b/src/store/scanStore.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { scanNewOnly, toggleScanNewOnly } from './scanStore';
+import { activeScan, loadScanSetup, resetScanAfterBattle, ScanMode, scanNewOnly, toggleScanNewOnly } from './scanStore';
 
 describe('scanStore', () => {
   describe('scanNewOnly', () => {
@@ -13,6 +13,32 @@ describe('scanStore', () => {
       expect(scanNewOnly()).toBe(true);
       toggleScanNewOnly();
       expect(scanNewOnly()).toBe(false);
+    });
+  });
+
+  describe('loadScanSetup', () => {
+    it('restores active scan from saved data', () => {
+      loadScanSetup({ deviceId: 'core_preserver', mode: ScanMode.Permanent });
+
+      expect(activeScan()).toEqual({ deviceId: 'core_preserver', mode: ScanMode.Permanent });
+    });
+  });
+
+  describe('resetScanAfterBattle', () => {
+    it('clears single mode after battle', () => {
+      loadScanSetup({ deviceId: 'core_preserver', mode: ScanMode.Single });
+
+      resetScanAfterBattle();
+
+      expect(activeScan()).toBeNull();
+    });
+
+    it('keeps permanent mode after battle even without stock', () => {
+      loadScanSetup({ deviceId: 'core_preserver', mode: ScanMode.Permanent });
+
+      resetScanAfterBattle();
+
+      expect(activeScan()).toEqual({ deviceId: 'core_preserver', mode: ScanMode.Permanent });
     });
   });
 });

--- a/src/store/scanStore.ts
+++ b/src/store/scanStore.ts
@@ -1,11 +1,9 @@
 import { createSignal } from 'solid-js';
 
-import { canScan } from '../game/Scan';
-
 export const ScanMode = { Off: 'off', Permanent: 'permanent', Single: 'single' } as const;
 export type ScanMode = (typeof ScanMode)[keyof typeof ScanMode];
 
-interface ActiveScan {
+export interface ActiveScan {
   deviceId: string;
   mode: ScanMode;
 }
@@ -21,10 +19,14 @@ function getActiveScanMode(): ScanMode {
   return activeScan()?.mode ?? ScanMode.Off;
 }
 
+function loadScanSetup(data: ActiveScan): void {
+  setActiveScan(data);
+}
+
 function resetScanAfterBattle(): void {
   const current = activeScan();
   if (!current) {return;}
-  if (current.mode === ScanMode.Single || !canScan(current.deviceId)) {
+  if (current.mode === ScanMode.Single) {
     setActiveScan(null);
   }
 }
@@ -49,4 +51,4 @@ function toggleScan(deviceId: string): void {
   }
 }
 
-export { activeScan, getActiveDeviceId, getActiveScanMode, resetScanAfterBattle, scanNewOnly, toggleScan, toggleScanNewOnly };
+export { activeScan, getActiveDeviceId, getActiveScanMode, loadScanSetup, resetScanAfterBattle, scanNewOnly, toggleScan, toggleScanNewOnly };

--- a/test/Save.test.ts
+++ b/test/Save.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Save } from '../src/game/Save';
 import { Currency } from '../src/models/Currency';
 import { DEFAULT_PARTY, ZoidResearchStatus } from '../src/models/Zoid';
+import { loadScanSetup, ScanMode } from '../src/store/scanStore';
 import { incrementRouteKills, loadStatistics } from '../src/store/statisticsStore';
 import { addCurrency, loadWallet } from '../src/store/walletStore';
 import { loadZoidResearch, updateZoidResearch } from '../src/store/zoidResearchStore';
@@ -60,6 +61,16 @@ describe('Save', () => {
     const loaded = save.load();
 
     expect(loaded?.wallet?.zi_metal).toBe(25);
+  });
+
+  it('should persist scan setup', () => {
+    loadScanSetup({ deviceId: 'core_preserver', mode: ScanMode.Permanent });
+    const save = new Save();
+
+    save.store();
+    const loaded = save.load();
+
+    expect(loaded?.scanSetup).toEqual({ deviceId: 'core_preserver', mode: ScanMode.Permanent });
   });
 
   it('should persist route kills', () => {


### PR DESCRIPTION
## Summary
- Persist the active scan selection (device + mode) in `SaveData` so auto mode survives across sessions
- Stop resetting permanent mode when preservers run out — `attemptScan` already guards with `canScan()`, so the selection stays dormant until the user buys more
- Add unit tests for save/load round-trip and reset behavior

Closes #104

## Test plan
- [x] All 295 tests pass
- [x] Set preserver to auto mode, use all preservers, buy more → verify auto mode is still active
- [x] Save and reload the game → verify scan setup is restored