### PR TITLE
Add deliver_girl mission, shells_of_time campaign, and rename girl to kara

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zoids-sleeper",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zoids-sleeper",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "dependencies": {
         "i18next": "^26.0.3",
         "solid-js": "^1.9.11"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zoids-sleeper",
   "private": true,
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/campaign/Campaign.ts
+++ b/src/campaign/Campaign.ts
@@ -9,6 +9,7 @@ export const CampaignStatus = {
 export type CampaignStatus = typeof CampaignStatus[keyof typeof CampaignStatus];
 
 export interface Mission {
+  devOnly?: boolean;
   goals: Requirement[];
   id: string;
   onComplete?: () => void;
@@ -16,6 +17,7 @@ export interface Mission {
 
 export interface Campaign {
   autoStart?: boolean;
+  devOnly?: boolean;
   id: string;
   missions: Mission[];
   unlockRequirements?: Requirement[];

--- a/src/campaign/campaigns.ts
+++ b/src/campaign/campaigns.ts
@@ -1,9 +1,18 @@
-import { AllOfRequirement, ArmySizeRequirement, ComparisonCondition, MissionCompletedRequirement, NpcTalkedInCampaignRequirement, PilotDefeatRequirement, RouteKillRequirement, ZiDataRequirement } from '../requirement';
+import { AllOfRequirement, ArmySizeRequirement, CampaignCompletedRequirement, ComparisonCondition, MissionCompletedRequirement, NpcTalkedInCampaignRequirement, PilotDefeatRequirement, RouteKillRequirement, ZiDataRequirement } from '../requirement';
 import { CUTSCENES } from '../cutscene';
 import { enqueueDialog } from '../store/gameStore';
 import type { Campaign } from './Campaign';
 
 export const CAMPAIGNS: Record<string, Campaign> = {
+  shells_of_time: {
+    autoStart: true,
+    devOnly: true,
+    id: 'shells_of_time',
+    missions: [
+      { id: 'head_to_porto_nido', goals: [new NpcTalkedInCampaignRequirement('shells_of_time', 'girl_father')] },
+    ],
+    unlockRequirements: [new CampaignCompletedRequirement('sleeper_commander')],
+  },
   sleeper_commander: {
     autoStart: true,
     id: 'sleeper_commander',
@@ -43,6 +52,7 @@ export const CAMPAIGNS: Record<string, Campaign> = {
       { id: 'check_van_colony', goals: [new NpcTalkedInCampaignRequirement('sleeper_commander', 'maria_flyheight')] },
       { id: 'find_van_oasis', goals: [new NpcTalkedInCampaignRequirement('sleeper_commander', 'van')] },
       { id: 'fight_van', goals: [new PilotDefeatRequirement('van_shield_liger')], onComplete: () => enqueueDialog(CUTSCENES.narration_van_farewell.toDialogScript()) },
+      { id: 'deliver_girl', goals: [new NpcTalkedInCampaignRequirement('sleeper_commander', 'woman')] },
     ],
   },
 };

--- a/src/campaign/campaigns.ts
+++ b/src/campaign/campaigns.ts
@@ -48,7 +48,7 @@ export const CAMPAIGNS: Record<string, Campaign> = {
       { id: 'rosso_confrontation', goals: [new NpcTalkedInCampaignRequirement('sleeper_commander', 'rosso')] },
       { id: 'fight_rosso', goals: [new PilotDefeatRequirement('rosso')], onComplete: () => enqueueDialog(CUTSCENES.narration_turtle_savior.toDialogScript()) },
       { id: 'fight_rosso_rematch', goals: [new PilotDefeatRequirement('rosso', 2)], onComplete: () => enqueueDialog(CUTSCENES.narration_bandits_flee.toDialogScript()) },
-      { id: 'talk_to_girl', goals: [new NpcTalkedInCampaignRequirement('sleeper_commander', 'girl')] },
+      { id: 'talk_to_girl', goals: [new NpcTalkedInCampaignRequirement('sleeper_commander', 'kara')] },
       { id: 'check_van_colony', goals: [new NpcTalkedInCampaignRequirement('sleeper_commander', 'maria_flyheight')] },
       { id: 'find_van_oasis', goals: [new NpcTalkedInCampaignRequirement('sleeper_commander', 'van')] },
       { id: 'fight_van', goals: [new PilotDefeatRequirement('van_shield_liger')], onComplete: () => enqueueDialog(CUTSCENES.narration_van_farewell.toDialogScript()) },

--- a/src/game/migrations.test.ts
+++ b/src/game/migrations.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+
+import type { MigrationData } from './migrations';
+import { migrate } from './migrations';
+
+function baseSave(overrides: Partial<MigrationData> = {}): MigrationData {
+  return {
+    campaigns: {
+      sleeper_commander: {
+        currentMission: 'talk_to_boy',
+        missionNpcFlags: {},
+        status: 'started',
+      },
+    },
+    landmarkId: 'gleam_village',
+    version: '0.4.1',
+    ...overrides,
+  };
+}
+
+describe('migration 0.4.2', () => {
+  it('resets completed campaign to deliver_girl', () => {
+    const data = baseSave({
+      campaigns: {
+        sleeper_commander: {
+          currentMission: 'fight_van',
+          missionNpcFlags: {},
+          status: 'completed',
+        },
+      },
+    });
+
+    migrate(data, '0.4.1');
+
+    expect(data.campaigns!['sleeper_commander']).toEqual({
+      currentMission: 'deliver_girl',
+      missionNpcFlags: {},
+      status: 'started',
+    });
+  });
+
+  it('does not affect players before fight_van', () => {
+    const data = baseSave();
+
+    migrate(data, '0.4.1');
+
+    expect(data.campaigns!['sleeper_commander'].currentMission).toBe('talk_to_boy');
+    expect(data.campaigns!['sleeper_commander'].status).toBe('started');
+  });
+
+  it('does not affect players on fight_van', () => {
+    const data = baseSave({
+      campaigns: {
+        sleeper_commander: {
+          currentMission: 'fight_van',
+          missionNpcFlags: {},
+          status: 'started',
+        },
+      },
+    });
+
+    migrate(data, '0.4.1');
+
+    expect(data.campaigns!['sleeper_commander'].currentMission).toBe('fight_van');
+    expect(data.campaigns!['sleeper_commander'].status).toBe('started');
+  });
+
+  it('does not affect saves without campaign data', () => {
+    const data = baseSave({ campaigns: undefined });
+
+    migrate(data, '0.4.1');
+
+    expect(data.campaigns).toBeUndefined();
+  });
+});

--- a/src/game/migrations.test.ts
+++ b/src/game/migrations.test.ts
@@ -72,4 +72,22 @@ describe('migration 0.4.2', () => {
 
     expect(data.campaigns).toBeUndefined();
   });
+
+  it('renames girl npc flag to kara in missionNpcFlags', () => {
+    const data = baseSave({
+      campaigns: {
+        sleeper_commander: {
+          currentMission: 'talk_to_girl',
+          missionNpcFlags: { 'sleeper_commander:girl': false },
+          status: 'started',
+        },
+      },
+    });
+
+    migrate(data, '0.4.1');
+
+    const flags = data.campaigns!['sleeper_commander'].missionNpcFlags!;
+    expect(flags['sleeper_commander:kara']).toBe(false);
+    expect(flags['sleeper_commander:girl']).toBeUndefined();
+  });
 });

--- a/src/game/migrations.ts
+++ b/src/game/migrations.ts
@@ -17,6 +17,13 @@ const migrations: Record<string, MigrationFn> = {
         missionNpcFlags: {},
         status: 'started',
       };
+      return;
+    }
+
+    const flags = campaign.missionNpcFlags;
+    if (flags?.['sleeper_commander:girl'] !== undefined) {
+      flags['sleeper_commander:kara'] = flags['sleeper_commander:girl'];
+      delete flags['sleeper_commander:girl'];
     }
   },
   '0.4.1': (data) => {

--- a/src/game/migrations.ts
+++ b/src/game/migrations.ts
@@ -7,6 +7,18 @@ export type MigrationData = Partial<SaveData> & Record<string, unknown>;
 type MigrationFn = (data: MigrationData) => void;
 
 const migrations: Record<string, MigrationFn> = {
+  '0.4.2': (data) => {
+    const campaign = data.campaigns?.['sleeper_commander'];
+    if (!campaign) {return;}
+
+    if (campaign.status === 'completed') {
+      data.campaigns!['sleeper_commander'] = {
+        currentMission: 'deliver_girl',
+        missionNpcFlags: {},
+        status: 'started',
+      };
+    }
+  },
   '0.4.1': (data) => {
     if (Array.isArray(data.party)) {
       const zoids = data.party as OwnedZoid[];

--- a/src/i18n/locales/en/campaigns.json
+++ b/src/i18n/locales/en/campaigns.json
@@ -1,4 +1,14 @@
 {
+  "shells_of_time": {
+    "description": "A father researching Zoids, a mysterious Dr T, and a family torn apart. Head to Porto Nido to find answers.",
+    "missions": {
+      "head_to_porto_nido": {
+        "description": "The girl's father is in Porto Nido. Head south to find him and warn him about the pursuers.",
+        "name": "The Road to Porto Nido"
+      }
+    },
+    "name": "Breaking the Shell"
+  },
   "sleeper_commander": {
     "description": "Gleam Village is under attack by Zoids Sleepers. Prove your skill as a pilot and uncover the culprits.",
     "missions": {
@@ -25,6 +35,10 @@
       "defeat_bul": {
         "description": "The bandits mentioned Blu, who's trying to get rid of a boy. Help Van by stopping Blu and his Guysack in a sortie through the Elmia Ruins.",
         "name": "Protector"
+      },
+      "deliver_girl": {
+        "description": "Take the girl back to her mother in Gleam Village.",
+        "name": "The Road Home"
       },
       "elmia_desert_patrol": {
         "description": "Maria says her brother Van is somewhere in the Elmia Desert. Fight through the Sleepers to find him.",

--- a/src/i18n/locales/en/dialog.json
+++ b/src/i18n/locales/en/dialog.json
@@ -35,6 +35,11 @@
     "But make no mistake, young pilot, not all army inventions are bad... If you earn its trust, this Sleeper system would allow you to bond with several Zoids at the same time.",
     "If you really plan to face those bandits, you could use some reinforcements. For that you'll need more Zoids. Why don't you talk to old Jenkins? He used to work in a Zoid laboratory, maybe he can help you."
   ],
+  "captain_pride": [
+    "I've been hearing stories about you, kid. Helping villagers, taking on bandits, protecting people you don't even know... You've become someone this region can count on.",
+    "You know, when I gave you that old Zoid of mine, I wasn't sure what to expect. But seeing what you've done with it... it fills this old soldier with pride.",
+    "These are dangerous times. The war between the Republic and the Empire is far from over, and people like you tend to attract attention from both sides. Watch your back out there."
+  ],
   "captain_farewell": [
     "Well, well! Now you actually look like a proper army commander. I can see you're determined to take on those bandits. Good luck, kid.",
     "Oh, one more thing. I took a closer look at that Sleeper module of yours. I wouldn't recommend deploying more than one Zoid of the same species. The module doesn't seem to allow live control of multiple Zoids of the same kind.",
@@ -199,5 +204,16 @@
     "I'm desperate... she's just a child. Please, you have to save her! Wind Colony is to the north. Be careful, the road is dangerous.",
     "Take this, it might be useful to you. Those bandits were using these devices to command the Zoids around this camp and keep soldiers from getting close.",
     "I managed to snatch one from the bandit who took my daughter. I don't really know what it is, but maybe that old man in the village would know."
+  ],
+  "woman_reunion": [
+    "My baby! You brought her back! I can't believe it... I thought I'd never see her again. Thank you... truly, thank you. I'll never forget what you've done for us.",
+    "Mom! I missed you so much! I was so scared, but this dude saved me!",
+    "Kara! Mind your manners, that's no way to speak about someone who helped us.",
+    "...",
+    "Listen... I need to ask you another favor. My husband has been researching Zoids for a long time. He says his work is very important. I don't know the details, but it seems it all started when he met someone called Dr. T.",
+    "The bandits were after him... and I don't think they'll stop. So please... take my daughter with you. I know it's a lot to ask, but it's the safest thing for her. If you could bring her to her father...",
+    "But Mom! I don't want to leave without you!",
+    "My darling, listen to me... I've already asked the Captain to keep your brother safe through his contacts in the army. He'll be working with one of the engineers. And I'll be leaving too, somewhere else... If we split up, it'll be much harder for them to find us.",
+    "I promise we'll see each other again. But right now I need you to be brave for me... Please, take care of my daughter. And tell my husband that dangerous people are after him, but that we're safe. Last I heard from him, he was working somewhere near Porto Nido."
   ]
 }

--- a/src/i18n/locales/en/pilots.json
+++ b/src/i18n/locales/en/pilots.json
@@ -11,6 +11,7 @@
   "fiona": "Fine",
   "giallo": "Giallo",
   "girl": "Girl",
+  "kara": "Kara",
   "jenkins": "Old Jenkins",
   "maria_flyheight": "Maria Flyheight",
   "nero": "Nero",

--- a/src/i18n/locales/es/campaigns.json
+++ b/src/i18n/locales/es/campaigns.json
@@ -1,4 +1,14 @@
 {
+  "shells_of_time": {
+    "description": "Un padre investigando Zoids, un misterioso Dr T y una familia separada. Dirígete a Porto Nido para encontrar respuestas.",
+    "missions": {
+      "head_to_porto_nido": {
+        "description": "El padre de la niña está en Porto Nido. Ve hacia el sur para encontrarlo y advertirle sobre los perseguidores.",
+        "name": "El Camino a Porto Nido"
+      }
+    },
+    "name": "Saliendo del Caparazón"
+  },
   "sleeper_commander": {
     "description": "La Aldea Destello es atacada por Zoids Sleepers, muestra tu habilidad como piloto y descubre a los culpables.",
     "missions": {
@@ -25,6 +35,10 @@
       "defeat_bul": {
         "description": "Los bandidos mencionaron a Blu, que intenta deshacerse de un niño. Ayuda a Van deteniendo a Blu y su Guysack incursionando en las Ruinas de Elmia.",
         "name": "Protector"
+      },
+      "deliver_girl": {
+        "description": "Lleva a la niña de vuelta con su madre en la Aldea Gleam.",
+        "name": "El Camino a Casa"
       },
       "elmia_desert_patrol": {
         "description": "María dice que su hermano Van está en algún lugar del Desierto de Elmia. Abre camino entre los Sleepers para encontrarlo.",

--- a/src/i18n/locales/es/dialog.json
+++ b/src/i18n/locales/es/dialog.json
@@ -35,6 +35,11 @@
     "Pero no te equivoques joven piloto, no todos los inventos del ejercito son malos... Si te ganas su confianza, este sistema Sleeper te permitiría crear lazos con varios Zoids al mismo tiempo",
     "Si de verdad piensas enfrentarte a esos bandidos te vendrían bien refuerzos. Para eso necesitarás más Zoids, por qué no hablas con el viejo Jenkins, el solía trabajar en un laboratorio de Zoids, tal vez pueda ayudarte."
   ],
+  "captain_pride": [
+    "He escuchado historias sobre ti, muchacho. Ayudando a los aldeanos, enfrentando bandidos, protegiendo a gente que ni conoces... Te has convertido en alguien con quien esta región puede contar.",
+    "Sabes, cuando te di ese viejo Zoid mío, no sabía qué esperar. Pero ver lo que has logrado con él... llena de orgullo a este viejo soldado.",
+    "Son tiempos peligrosos. La guerra entre la República y el Imperio está lejos de terminar, y la gente como tú tiende a atraer la atención de ambos bandos. Cuídate mucho ahí fuera."
+  ],
   "captain_farewell": [
     "¡Vaya! Ahora sí pareces todo un comandante con tu propia armada. Veo que estás decidido a hacerle frente a esos bandidos. Buena suerte, muchacho.",
     "Ah, una cosa más. Le eché un vistazo más de cerca a ese módulo Sleeper tuyo. No te recomendaría desplegar más de un Zoid de la misma especie. El módulo no parece permitir el control simultáneo de multiples Zoids de la misma especie.",
@@ -199,5 +204,16 @@
     "Estoy desesperada... es solo una niña. ¡Por favor, tienes que salvarla! La Colonia del Viento está al norte. Ten cuidado, el camino es peligroso.",
     "Toma esto, tal vez te sea útil. Esos bandidos estaban usando estos dispositivos para comandar a los Zoids alrededor de este campamento y evitar que se acerquen los soldados.",
     "Logré arrebatarle uno al que se llevó a mi hija. La verdad no se qué sea pero tal vez ese anciano de la aldea sepa qué es."
+  ],
+  "woman_reunion": [
+    "¡Mi niña! ¡La trajiste de vuelta! No puedo creerlo... pensé que nunca la volvería a ver. Gracias... de verdad, gracias. Nunca olvidaré lo que has hecho por nosotras.",
+    "¡Mamá! ¡Te extrañé mucho! Tenía mucho miedo, pero este tipo me salvó.",
+    "¡Kara! Sé educada, no es forma de hablarle a quien nos ha ayudado.",
+    "...",
+    "Escucha... necesito pedirte otro favor. Mi esposo lleva mucho tiempo investigando sobre Zoids. Dice que su trabajo es muy importante, no sé de qué se trate pero al parecer todo empezó cuando conoció a alguien llamado Dr. T.",
+    "Los bandidos lo buscaban a él... y no creo que esto se detenga. Así que... por favor, llévate a mi hija. Sé que es mucho pedir, pero es lo más seguro para ella. Si pudieras llevarla con su padre...",
+    "¡Pero mamá! ¡No me quiero ir sin ti!",
+    "Mi amor, escúchame... ya le pedí al Capitán que ponga a tu hermano a salvo con sus contactos en el ejército, él estará trabajando con uno de los ingenieros. Y yo también me iré, a otro lugar... Si nos separamos, será mucho más difícil que nos encuentren.",
+    "Te prometo que nos volveremos a ver. Pero ahora necesito que seas valiente por mí... Por favor, cuida a mi hija. Y dile a mi esposo que gente peligrosa lo está buscando, pero que estamos a salvo. La última vez que lo contacté se encontraba trabajando cerca de Porto Nido."
   ]
 }

--- a/src/i18n/locales/es/pilots.json
+++ b/src/i18n/locales/es/pilots.json
@@ -11,6 +11,7 @@
   "fiona": "Fine",
   "giallo": "Giallo",
   "girl": "Niña",
+  "kara": "Kara",
   "jenkins": "Viejo Jenkins",
   "maria_flyheight": "María Flyheight",
   "nero": "Nero",

--- a/src/landmark/City.ts
+++ b/src/landmark/City.ts
@@ -44,7 +44,7 @@ export const CITIES: City[] = [
       new ActionTalkToNPC('rosso', [new MissionCompletedRequirement(C, 'ambush_arcobaleno')], [new MissionCompletedRequirement(C, 'rosso_confrontation')]),
       new ActionFightPilot(PILOTS['rosso'], [new MissionCompletedRequirement(C, 'rosso_confrontation')], [new PilotDefeatRequirement('rosso')], true),
       new ActionFightPilot(PILOTS['rosso'], [new PilotDefeatRequirement('rosso')], [new PilotDefeatRequirement('rosso', 2)]),
-      new ActionTalkToNPC('girl', [new MissionCompletedRequirement(C, 'fight_rosso_rematch')], [new NpcTalkedInCampaignRequirement(C, 'girl')]),
+      new ActionTalkToNPC('kara', [new MissionCompletedRequirement(C, 'fight_rosso_rematch')], [new MissionCompletedRequirement(C, 'deliver_girl')]),
     ],
     battleBackground: BattleBackground.Desert,
     id: 'arcobaleno_camp',

--- a/src/landmark/City.ts
+++ b/src/landmark/City.ts
@@ -64,6 +64,7 @@ export const CITIES: City[] = [
       new ActionTalkToNPC('captain_malinoff', [new MissionCompletedRequirement(C, 'grow_army')]),
       new ActionTalkToNPC('jenkins', [new MissionCompletedRequirement(C, 'report_to_captain')], [new MissionCompletedRequirement(C, 'jenkins_to_work')], itemReward(ITEMS.core_analyzer.id, 1, true)),
       new ActionTalkToNPC('scrap_dealer'),
+      new ActionTalkToNPC('woman', [new MissionCompletedRequirement(C, 'fight_van')]),
     ],
     battleBackground: BattleBackground.Grass,
     id: 'gleam_village',

--- a/src/models/PopupMessage.ts
+++ b/src/models/PopupMessage.ts
@@ -1,4 +1,4 @@
-export const PopupType = { Defeat: 'defeat', Item: 'item', Mission: 'mission', Victory: 'victory' } as const;
+export const PopupType = { Campaign: 'campaign', Defeat: 'defeat', Item: 'item', Mission: 'mission', Victory: 'victory' } as const;
 export type PopupType = (typeof PopupType)[keyof typeof PopupType];
 
 export class PopupMessage {

--- a/src/npc/Npc.ts
+++ b/src/npc/Npc.ts
@@ -70,10 +70,10 @@ export const NPCS: Record<string, Npc> = {
     nameKey: 'pilots:fiona',
     portrait: 'images/pilots/fiona.png',
   },
-  girl: {
-    dialogs: [{ dialogKey: 'dialog:girl_thanks' }],
-    id: 'girl',
-    nameKey: 'pilots:girl',
+  kara: {
+    dialogs: [{ dialogKey: 'dialog:girl_thanks', speakers: { 0: { speakerKey: 'pilots:girl' } } }],
+    id: 'kara',
+    nameKey: 'pilots:kara',
     portrait: 'images/pilots/girl.png',
   },
   captain_malinoff: {
@@ -148,7 +148,7 @@ export const NPCS: Record<string, Npc> = {
     dialogs: [
       {
         dialogKey: 'dialog:woman_reunion',
-        speakers: { 1: { speakerKey: 'pilots:girl' }, 2: { speakerKey: '' }, 3: { speakerKey: 'pilots:girl' }, 4: { speakerKey: '' }, 6: { speakerKey: 'pilots:girl' }, 7: { speakerKey: '' } },
+        speakers: { 1: { speakerKey: 'pilots:girl' }, 2: { speakerKey: '' }, 3: { speakerKey: 'pilots:kara' }, 4: { speakerKey: '' }, 6: { speakerKey: 'pilots:kara' }, 7: { speakerKey: '' } },
         unlockRequirement: new MissionCompletedRequirement('sleeper_commander', 'fight_van'),
       },
       { dialogKey: 'dialog:woman' },

--- a/src/npc/Npc.ts
+++ b/src/npc/Npc.ts
@@ -79,6 +79,10 @@ export const NPCS: Record<string, Npc> = {
   captain_malinoff: {
     dialogs: [
       {
+        dialogKey: 'dialog:captain_pride',
+        unlockRequirement: new MissionCompletedRequirement('sleeper_commander', 'fight_van'),
+      },
+      {
         dialogKey: 'dialog:captain_farewell',
         unlockRequirement: new MissionCompletedRequirement('sleeper_commander', 'grow_army'),
       },
@@ -142,6 +146,11 @@ export const NPCS: Record<string, Npc> = {
   },
   woman: {
     dialogs: [
+      {
+        dialogKey: 'dialog:woman_reunion',
+        speakers: { 1: { speakerKey: 'pilots:girl' }, 2: { speakerKey: '' }, 3: { speakerKey: 'pilots:girl' }, 4: { speakerKey: '' }, 6: { speakerKey: 'pilots:girl' }, 7: { speakerKey: '' } },
+        unlockRequirement: new MissionCompletedRequirement('sleeper_commander', 'fight_van'),
+      },
       { dialogKey: 'dialog:woman' },
     ],
     id: 'woman',

--- a/src/store/campaignStore.test.ts
+++ b/src/store/campaignStore.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+
+import { CampaignStatus, type Campaign } from '../campaign/Campaign';
+import { CampaignCompletedRequirement } from '../requirement/CampaignCompletedRequirement';
+import { NpcTalkedInCampaignRequirement } from '../requirement/NpcTalkedInCampaignRequirement';
+import { campaignStates, checkCampaigns, loadCampaigns } from './campaignStore';
+
+function stubCampaign(overrides: Partial<Campaign> = {}): Campaign {
+  return {
+    autoStart: true,
+    id: 'test_campaign',
+    missions: [
+      { id: 'first_mission', goals: [new NpcTalkedInCampaignRequirement('test_campaign', 'npc')] },
+    ],
+    ...overrides,
+  };
+}
+
+describe('checkCampaigns', () => {
+  it('auto-starts a campaign with no unlock requirements', () => {
+    const campaign = stubCampaign({ id: 'auto_start' });
+    loadCampaigns({ auto_start: campaign }, {});
+
+    checkCampaigns();
+
+    expect(campaignStates()['auto_start']?.status).toBe(CampaignStatus.Started);
+  });
+
+  it('auto-starts devOnly campaigns in dev mode', () => {
+    const campaign = stubCampaign({ devOnly: true, id: 'dev_campaign' });
+    loadCampaigns({ dev_campaign: campaign }, {});
+
+    checkCampaigns();
+
+    expect(campaignStates()['dev_campaign']?.status).toBe(CampaignStatus.Started);
+  });
+
+  it('does not auto-start a campaign with unmet unlock requirements', () => {
+    const campaign = stubCampaign({
+      id: 'locked_campaign',
+      unlockRequirements: [new CampaignCompletedRequirement('nonexistent')],
+    });
+    loadCampaigns({ locked_campaign: campaign }, {});
+
+    checkCampaigns();
+
+    expect(campaignStates()['locked_campaign']).toBeUndefined();
+  });
+
+  it('chains campaigns via CampaignCompletedRequirement', () => {
+    const first = stubCampaign({ id: 'first' });
+    const second = stubCampaign({
+      id: 'second',
+      unlockRequirements: [new CampaignCompletedRequirement('first')],
+    });
+    loadCampaigns(
+      { first, second },
+      { first: { currentMission: '', missionNpcFlags: {}, status: CampaignStatus.Completed } }
+    );
+
+    checkCampaigns();
+
+    expect(campaignStates()['second']?.status).toBe(CampaignStatus.Started);
+  });
+});

--- a/src/store/campaignStore.ts
+++ b/src/store/campaignStore.ts
@@ -37,6 +37,14 @@ function advanceMission(campaignId: string): void {
     t('ui:mission_completed'),
     PopupType.Mission
   ));
+
+  if (completed) {
+    showPopup(new PopupMessage(
+      t(`campaigns:${campaignId}.name`),
+      t('ui:campaign_completed'),
+      PopupType.Campaign
+    ));
+  }
 }
 
 function buildNpcFlags(campaign: Campaign, missionIndex: number): Record<string, boolean> {
@@ -127,9 +135,15 @@ function forceSetMission(campaignId: string, missionId: string): void {
   }));
 }
 
+function isDevMode(): boolean {
+  return import.meta.env.DEV;
+}
+
 function checkCampaigns(): void {
   const states = campaignStates();
   for (const campaign of Object.values(campaigns)) {
+    if (campaign.devOnly && !isDevMode()) {continue;}
+
     const state = states[campaign.id];
 
     if (campaign.autoStart && (!state || state.status === CampaignStatus.Inactive)) {


### PR DESCRIPTION
## Summary
- Add `deliver_girl` mission to `sleeper_commander` campaign — player takes Kara back to her mother in Gleam Village
- Expand `woman_reunion` dialog with family backstory, Dr. T exposition, and mother's request to take Kara to Porto Nido
- Add `shells_of_time` stub campaign (dev-only) that auto-starts after completing `sleeper_commander`
- Add `devOnly` feature flag for campaigns, filtered in `checkCampaigns()`
- Add campaign completion popup via `PopupType.Campaign`
- Add captain Malinoff post-fight_van dialog (`captain_pride`)
- Rename girl NPC id to `kara`, with migration for save data flags
- Kara's name shows as "Girl"/"Niña" in pre-reveal dialogs, "Kara" after the mother names her
- Save migration 0.4.2 resets completed campaigns to `deliver_girl` and renames NPC flags

## Test plan
- [x] Build passes
- [x] 304 tests pass (migration tests, campaign store tests)
- [x] In dev: complete fight_van → talk to Kara in Arcobaleno → deliver to Gleam Village → woman_reunion dialog plays → sleeper_commander completes → shells_of_time starts
- [x] Kara action disappears from Arcobaleno after deliver_girl
- [x] Kara shows as "Girl" in girl_thanks and first line of woman_reunion, "Kara" from line 3 onward
- [x] Campaign completion popup appears when sleeper_commander finishes

Closes #131