### PR TITLE
Fix sortie and battle mobile layout (#130)

### DIFF
--- a/src/dungeon/DungeonMapScreen.tsx
+++ b/src/dungeon/DungeonMapScreen.tsx
@@ -24,7 +24,10 @@ const NODE_ICONS: Record<SortieNodeType, string> = {
   [SortieNodeType.Supply]: '\u{1F4E6}',
 };
 
+const MIN_LAYER_WIDTH = 60;
+
 const DungeonMapScreen: Component<Props> = (props) => {
+  let containerRef: HTMLDivElement | undefined;
   let layersRef: HTMLDivElement | undefined;
   let markerRef: HTMLImageElement | undefined;
   let svgRef: SVGSVGElement | undefined;
@@ -150,17 +153,49 @@ const DungeonMapScreen: Component<Props> = (props) => {
     markerRef.addEventListener('transitionend', onMarkerEnd, { once: true });
   }
 
+  let scrollOffset = 0;
+  let touchStartX = 0;
+  let startOffset = 0;
+
+  function getMaxScroll(): number {
+    if (!layersRef || !containerRef) {return 0;}
+    const layerCount = visibleLayers().length;
+    const minLayerWidth = MIN_LAYER_WIDTH;
+    const neededWidth = layerCount * minLayerWidth;
+    const containerWidth = containerRef.clientWidth;
+    return Math.max(0, neededWidth - containerWidth);
+  }
+
+  function applyScroll(): void {
+    if (!layersRef) {return;}
+    layersRef.style.left = `${-scrollOffset}px`;
+    layersRef.style.width = `calc(100% + ${scrollOffset}px)`;
+  }
+
+  function handleTouchStart(e: TouchEvent): void {
+    touchStartX = e.touches[0].clientX;
+    startOffset = scrollOffset;
+  }
+
+  function handleTouchMove(e: TouchEvent): void {
+    const dx = touchStartX - e.touches[0].clientX;
+    scrollOffset = Math.max(0, Math.min(getMaxScroll(), startOffset + dx));
+    applyScroll();
+    drawConnections();
+  }
+
   createEffect(() => {
     visibleLayers();
     if (!isLayerAdvancing()) {
       const el = layersRef;
       if (el) {
-        el.style.width = '';
         el.style.transform = '';
         el.style.transition = 'none';
       }
+      scrollOffset = 0;
       requestAnimationFrame(() => {
         requestAnimationFrame(() => {
+          applyScroll();
           drawConnections();
           const nodeId = lastCompletedNodeId();
           if (nodeId) {positionMarkerOn(nodeId, false);}
@@ -179,6 +214,9 @@ const DungeonMapScreen: Component<Props> = (props) => {
       <p class="dungeon-subtitle">{t('ui:select_path')}</p>
       <div
         class="dungeon-graph-container"
+        ref={containerRef}
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
         style={{ 'background-image': `url('${landmarkBackground()}')`, 'background-size': 'cover' }}
       >
         <div class="dungeon-layers" ref={layersRef}>
@@ -194,7 +232,7 @@ const DungeonMapScreen: Component<Props> = (props) => {
               const r = run()!;
               const isCurrent = () => layer.depth === r.currentDepth;
               return (
-                <div class="dungeon-layer">
+                <div class="dungeon-layer" style={{ 'min-width': `${MIN_LAYER_WIDTH}px` }}>
                   <For each={layer.nodes}>
                     {(node) => {
                       const isCompleted = () => r.nodeResults[node.id] === 'completed';

--- a/src/dungeon/DungeonSupplyScreen.tsx
+++ b/src/dungeon/DungeonSupplyScreen.tsx
@@ -48,10 +48,10 @@ const DungeonSupplyScreen: Component<Props> = (props) => {
             </button>
           )}
         </For>
-        <button class="supply-option-btn supply-skip-btn" onClick={() => props.onComplete()}>
-          {t('dungeon:supply_skip')}
-        </button>
       </div>
+      <button class="supply-skip-btn" onClick={() => props.onComplete()}>
+        {t('dungeon:supply_skip')}
+      </button>
     </div>
   );
 };

--- a/src/dungeon/dungeon.css
+++ b/src/dungeon/dungeon.css
@@ -89,8 +89,8 @@
 .dungeon-layer {
   align-items: center;
   display: flex;
-  flex: 1;
   flex-direction: column;
+  flex-shrink: 0;
   gap: 0.8rem;
   justify-content: center;
 }
@@ -317,7 +317,9 @@
 
 .event-choices {
   display: flex;
+  flex-wrap: wrap;
   gap: 1rem;
+  justify-content: center;
 }
 
 .event-choice-btn {
@@ -388,6 +390,7 @@
 .supply-options {
   display: flex;
   gap: 1rem;
+  justify-content: center;
 }
 
 .supply-option-btn {
@@ -401,7 +404,7 @@
   flex-direction: column;
   font-size: 0.95rem;
   gap: 0.3rem;
-  padding: 0.8rem 1.2rem;
+  padding: 0.3rem 0.5rem;
   transition: all 0.2s;
 }
 
@@ -425,8 +428,14 @@
 
 .supply-skip-btn {
   background: linear-gradient(180deg, #2a2a2a, #1a1a1a);
-  border-color: #666;
-  justify-content: center;
+  border: 2px solid #666;
+  border-radius: 8px;
+  color: #e0e0e0;
+  cursor: pointer;
+  font-size: 0.95rem;
+  padding: 0.6rem;
+  transition: all 0.2s;
+  width: 100%;
 }
 
 .supply-skip-btn:hover {
@@ -543,7 +552,25 @@
   .dungeon-event-screen,
   .dungeon-map-screen,
   .dungeon-supply-screen {
-    height: 40vh;
+    height: 45vh;
+  }
+
+  .dungeon-node {
+    height: 42px;
+    width: 42px;
+  }
+
+  .dungeon-layer {
+    gap: 0.5rem;
+  }
+
+  .node-icon {
+    font-size: 1.1rem;
+  }
+
+  .player-marker {
+    height: 36px;
+    width: 36px;
   }
 }
 
@@ -559,6 +586,28 @@
   .dungeon-event-screen,
   .dungeon-map-screen,
   .dungeon-supply-screen {
-    height: 35vh;
+    height: 45vh;
+  }
+
+  .dungeon-node {
+    height: 36px;
+    width: 36px;
+  }
+
+  .dungeon-layer {
+    gap: 0.4rem;
+  }
+
+  .dungeon-layers {
+    padding: 0.5rem 0.3rem;
+  }
+
+  .node-icon {
+    font-size: 1rem;
+  }
+
+  .player-marker {
+    height: 30px;
+    width: 30px;
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -168,6 +168,7 @@ body {
 
 .battle-column {
   flex: 2;
+  min-width: 0;
   position: relative;
 }
 
@@ -286,7 +287,7 @@ body {
   }
 
   .battle-screen {
-    height: 40vh;
+    height: 45vh;
     padding: 0.5rem;
   }
 
@@ -305,6 +306,12 @@ body {
 
   .party-panel {
     width: 100%;
+  }
+
+  .archive-button {
+    font-size: 0.8rem;
+    height: 1.8rem;
+    width: 1.8rem;
   }
 
   .player-stats-row {
@@ -335,7 +342,7 @@ body {
 
   .battle-screen {
     border-radius: 8px;
-    height: 35vh;
+    height: 45vh;
     padding: 0.3rem;
   }
 

--- a/src/ui/battle.css
+++ b/src/ui/battle.css
@@ -75,7 +75,6 @@
   flex: 1;
   justify-content: center;
   min-height: 0;
-  margin-top: 1rem;
   overflow: hidden;
   position: relative;
   transition: border-color 0.2s;


### PR DESCRIPTION
## Summary
- Add touch-scroll to dungeon map for sorties with many layers
- Reduce dungeon node and marker sizes on mobile breakpoints
- Fix supply screen: move skip button below options as full-width button
- Add flex-wrap to event choices for mobile
- Increase battle/dungeon screen heights on mobile (35-40vh → 45vh)
- Remove unnecessary margin-top from battle area
- Reduce archive info button size on mobile
- Reduce supply option button padding

## Test plan
- [x] Test sortie map on mobile — nodes should be smaller, touch-scroll works when layers overflow
- [x] Test supply screen — options in a row, skip button below full-width
- [x] Test event screen — choices wrap on narrow screens
- [x] Test battle screen — more vertical space on mobile
- [x] Test on desktop — no regressions