### PR TITLE
Hide scan rate when out of preservers (#129)

### DIFF
--- a/src/dungeon/DungeonBattleScreen.tsx
+++ b/src/dungeon/DungeonBattleScreen.tsx
@@ -1,5 +1,5 @@
 import { type Component, Show } from 'solid-js';
-import { calculateScanRate } from '../game/Scan';
+import { getActiveScanRate } from '../game/Scan';
 import { t } from '../i18n';
 import { getZoidImage } from '../models/Zoid';
 import {
@@ -9,7 +9,7 @@ import {
   pilotPlayerMaxHealth,
 } from '../store/gameStore';
 import { battleBackground } from '../store/landmarkStore';
-import { getActiveDeviceId, getActiveScanMode, ScanMode } from '../store/scanStore';
+import { getActiveDeviceId, getActiveScanMode } from '../store/scanStore';
 import DamageNumber from '../ui/DamageNumber';
 import HealthBar from '../ui/HealthBar';
 import RewardNumber from '../ui/RewardNumber';
@@ -22,15 +22,17 @@ interface Props {
 }
 
 const DungeonBattleScreen: Component<Props> = (props) => {
+  const scanRate = () => getActiveScanRate(getActiveScanMode(), getActiveDeviceId(), enemyZoid()?.id ?? null);
+
   return (
     <div class="battle-screen">
       <div class="enemy-section">
         <h2 class="enemy-name">{enemyZoid()?.name ?? t('ui:unknown')}</h2>
         <HealthBar />
         <div class={`battle-area bg-${battleBackground()}`} onClick={() => props.onClick()}>
-          <Show when={getActiveScanMode() !== ScanMode.Off && getActiveDeviceId() && enemyZoid() && calculateScanRate(enemyZoid()!.id, getActiveDeviceId()!) > 0}>
+          <Show when={scanRate() > 0}>
             <p class="scan-rate">
-              {t('ui:scan_rate', { rate: calculateScanRate(enemyZoid()!.id, getActiveDeviceId()!) })}
+              {t('ui:scan_rate', { rate: scanRate() })}
             </p>
           </Show>
           {enemyZoid()?.id && (

--- a/src/game/Scan.test.ts
+++ b/src/game/Scan.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { addItem, removeItem } from '../store/inventoryStore';
+import { ScanMode } from '../store/scanStore';
+import { getActiveScanRate } from './Scan';
+
+describe('getActiveScanRate', () => {
+  afterEach(() => {
+    removeItem('core_preserver', 99);
+  });
+
+  it('returns 0 when scan mode is off', () => {
+    expect(getActiveScanRate(ScanMode.Off, 'core_preserver', 'merda')).toBe(0);
+  });
+
+  it('returns 0 when device id is null', () => {
+    expect(getActiveScanRate(ScanMode.Permanent, null, 'merda')).toBe(0);
+  });
+
+  it('returns 0 when enemy id is null', () => {
+    addItem('core_preserver', 1);
+
+    expect(getActiveScanRate(ScanMode.Permanent, 'core_preserver', null)).toBe(0);
+  });
+
+  it('returns 0 when device has no stock', () => {
+    expect(getActiveScanRate(ScanMode.Permanent, 'core_preserver', 'merda')).toBe(0);
+  });
+
+  it('returns scan rate when all conditions are met', () => {
+    addItem('core_preserver', 1);
+
+    expect(getActiveScanRate(ScanMode.Permanent, 'core_preserver', 'merda')).toBe(75);
+  });
+
+  it('returns 0 for unscannable zoid', () => {
+    addItem('core_preserver', 1);
+
+    expect(getActiveScanRate(ScanMode.Permanent, 'core_preserver', 'elephantus')).toBe(0);
+  });
+});

--- a/src/game/Scan.ts
+++ b/src/game/Scan.ts
@@ -5,6 +5,7 @@ import { getZoidById, getZoidImage, ZoidResearchStatus } from '../models/Zoid';
 import { showPopup } from '../store/gameStore';
 import { getItemCount, inventory, removeItem } from '../store/inventoryStore';
 import { party } from '../store/partyStore';
+import { ScanMode } from '../store/scanStore';
 import { getZoidDataCount, incrementZoidData } from '../store/zoidDataStore';
 import { updateZoidResearch } from '../store/zoidResearchStore';
 
@@ -39,6 +40,11 @@ export function calculateScanRate(zoidId: string, probeId: string): number {
 
 export function canScan(probeId: string): boolean {
   return getItemCount(probeId) > 0;
+}
+
+export function getActiveScanRate(mode: ScanMode, deviceId: string | null, enemyId: string | null): number {
+  if (mode === ScanMode.Off || !deviceId || !canScan(deviceId) || !enemyId) {return 0;}
+  return calculateScanRate(enemyId, deviceId);
 }
 
 export function getAvailableProbe(): string | null {

--- a/src/ui/BattleScreen.tsx
+++ b/src/ui/BattleScreen.tsx
@@ -1,11 +1,11 @@
 import { createSignal, For, Show, type Component } from 'solid-js';
-import { calculateScanRate } from '../game/Scan';
+import { getActiveScanRate } from '../game/Scan';
 import { t } from '../i18n';
 import type { Route } from '../landmark';
 import { getZoidImage } from '../models/Zoid';
 import { enemyZoid, showClickHint } from '../store/gameStore';
 import { battleBackground, currentLandmark, isOnRoute } from '../store/landmarkStore';
-import { getActiveDeviceId, getActiveScanMode, ScanMode } from '../store/scanStore';
+import { getActiveDeviceId, getActiveScanMode } from '../store/scanStore';
 import { getZoidResearch } from '../store/zoidResearchStore';
 import { ArchiveCard } from './ZiArchivePanel';
 import './archive.css';
@@ -22,6 +22,8 @@ interface BattleScreenProps {
 
 const BattleScreen: Component<BattleScreenProps> = (props) => {
   const [showInfo, setShowInfo] = createSignal(false);
+
+  const scanRate = () => getActiveScanRate(getActiveScanMode(), getActiveDeviceId(), enemyZoid()?.id ?? null);
 
   const routeEnemies = () => {
     if (!isOnRoute()) { return []; }
@@ -41,9 +43,9 @@ const BattleScreen: Component<BattleScreenProps> = (props) => {
         </div>
         <HealthBar />
         <div class={`battle-area bg-${battleBackground()}`} onClick={() => props.onClick()}>
-          <Show when={getActiveScanMode() !== ScanMode.Off && getActiveDeviceId() && enemyZoid() && calculateScanRate(enemyZoid()!.id, getActiveDeviceId()!) > 0}>
+          <Show when={scanRate() > 0}>
             <p class="scan-rate">
-              {t('ui:scan_rate', { rate: calculateScanRate(enemyZoid()!.id, getActiveDeviceId()!) })}
+              {t('ui:scan_rate', { rate: scanRate() })}
             </p>
           </Show>
           {enemyZoid()?.id && (


### PR DESCRIPTION
Fixes #129 
## Summary
- Add `getActiveScanRate` helper that checks scan mode, device availability, and item stock before returning a rate
- Replace inline scan rate logic in `BattleScreen` and `DungeonBattleScreen` with the new helper
- Hide the "Prob. de análisis" text when the player has no core preservers left

## Test plan
- [x] Unit tests for `getActiveScanRate` covering all edge cases (mode off, no device, no stock, unscannable zoid)
- [x] Run out of core preservers in a route battle and verify the scan rate text disappears
- [x] Run out of core preservers in a dungeon battle and verify the same