### PR TITLE
Add wild zoid dungeon boss support (#46)

### DIFF
--- a/src/dungeon/DungeonBattle.ts
+++ b/src/dungeon/DungeonBattle.ts
@@ -1,13 +1,12 @@
 import { BaseBattle } from '../game/BaseBattle';
 import { buildDropPool, rollDrops } from '../item/rollDrops';
 import { grantCurrencyReward } from '../store/walletStore';
-import type { PlayerStats } from '../models/Player';
 import { spawnZoid, buildZoid, getZoidById, ZoidResearchStatus } from '../models/Zoid';
 
 import { emitRewardEvent, setEnemyZoid, setPilotPlayerHealth, setPilotPlayerMaxHealth } from '../store/gameStore';
 import { resetScanAfterBattle } from '../store/scanStore';
 import { updateZoidResearch } from '../store/zoidResearchStore';
-import type { DungeonEnemy } from './DungeonSortieConfig';
+import { WildDungeonBoss, type DungeonEnemy } from './DungeonSortieConfig';
 import type { DungeonSortieEvent } from './DungeonSortieEvent';
 import { changePlayerHealth, dungeonRun, isPlayerDead } from './dungeonStore';
 import { SortieNodeType, type SortieNodeType as SortieNodeTypeValue } from './DungeonGraph';
@@ -21,8 +20,8 @@ export class DungeonBattle extends BaseBattle {
   private config: DungeonSortieEvent;
   private nodeType: SortieNodeTypeValue;
 
-  constructor(playerStats: PlayerStats, config: DungeonSortieEvent, nodeType: SortieNodeTypeValue) {
-    super(playerStats);
+  constructor(config: DungeonSortieEvent, nodeType: SortieNodeTypeValue) {
+    super();
     this.config = config;
     this.nodeType = nodeType;
     this.enemies = this.buildEnemyList(nodeType);
@@ -48,8 +47,8 @@ export class DungeonBattle extends BaseBattle {
   }
 
   protected onEnemyDefeated(): void {
-    const rewardMultiplier = this.nodeType === SortieNodeType.Elite ? 3 : 1;
-    const scanned = this.nodeType !== SortieNodeType.Boss && this.tryScan();
+    const rewardMultiplier = this.getRewardMultiplier();
+    const scanned = this.tryScan();
     const reward = grantCurrencyReward(this.config.baseReward, rewardMultiplier, scanned);
     emitRewardEvent(reward.magnis, 'magnis');
     emitRewardEvent(reward.ziMetal, 'zi_metal');
@@ -79,12 +78,27 @@ export class DungeonBattle extends BaseBattle {
     setPilotPlayerHealth(run.playerHealth);
   }
 
+  private buildBossEnemy(): DungeonEnemy[] {
+    const boss = dungeonRun()?.boss;
+    if (boss instanceof WildDungeonBoss) {return [{ zoidData: boss.zoidData }];}
+    return [];
+  }
+
   private buildEnemyList(nodeType: SortieNodeTypeValue): DungeonEnemy[] {
+    if (nodeType === SortieNodeType.Boss) {return this.buildBossEnemy();}
     const pool = nodeType === SortieNodeType.Elite ? this.config.eliteEnemies : this.config.enemies;
     const available = pool.filter((e) => e.requirement?.isCompleted() ?? true);
     const source = available.length > 0 ? available : pool.slice(0, 1);
     const count = nodeType === SortieNodeType.Elite ? randomBetween(1, 3) : 1;
     return Array.from({ length: count }, () => pickRandom(source));
+  }
+
+  private getRewardMultiplier(): number {
+    switch (this.nodeType) {
+      case SortieNodeType.Boss: return 5;
+      case SortieNodeType.Elite: return 3;
+      default: return 1;
+    }
   }
 
   private nextEnemy(): void {

--- a/src/dungeon/DungeonMapScreen.test.ts
+++ b/src/dungeon/DungeonMapScreen.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { DungeonEvent, DungeonEventChoice, HealOutcome } from './DungeonEventOutcome';
+import { BossTier, PilotBossEntry } from './DungeonSortieConfig';
 import { DungeonSortieEvent } from './DungeonSortieEvent';
 import { ENTRY_NODE_ID } from './generateSortie';
 import {
@@ -17,7 +18,7 @@ const DUMMY_EVENT = new DungeonEvent('e1', 'test', [new DungeonEventChoice('ok',
 
 const DUMMY_SORTIE = new DungeonSortieEvent({
   baseReward: { magnis: 100 },
-  bossTiers: [{ pilots: ['bandit1'] }],
+  bossTiers: [new BossTier([new PilotBossEntry('bandit1')])],
   eliteEnemies: [],
   enemies: [{ zoidData: { id: 'gator', level: 1 } }],
   entryCost: 0,

--- a/src/dungeon/DungeonMapScreen.tsx
+++ b/src/dungeon/DungeonMapScreen.tsx
@@ -1,11 +1,11 @@
 import { type Component, createEffect, createMemo, createSignal, For, Show } from 'solid-js';
 import { t } from '../i18n';
-import { getPilotImage } from '../models/Pilot';
 import { playerStats } from '../store/gameStore';
 import { landmarkBackground } from '../store/landmarkStore';
 import { getZoidResearch } from '../store/zoidResearchStore';
 import { ArchiveCard } from '../ui/ZiArchivePanel';
 import '../ui/archive.css';
+import type { BossPreview } from './DungeonSortieConfig';
 import { type SortieNode, SortieNodeType } from './DungeonGraph';
 import { type DungeonRunState, dungeonRun, isLayerAdvancing, setIsLayerAdvancing } from './dungeonStore';
 import './dungeon.css';
@@ -259,11 +259,11 @@ const DungeonMapScreen: Component<Props> = (props) => {
           <span class="dungeon-boss-title">{t('dungeon:possible_bosses')}</span>
           <div class="dungeon-boss-images">
             <For each={possibleBosses()}>
-              {(pilotId) => (
+              {(preview: BossPreview) => (
                 <img
-                  class="dungeon-boss-preview"
-                  src={getPilotImage(pilotId)}
-                  alt={pilotId}
+                  class={`dungeon-boss-preview${preview.isZoid && !getZoidResearch(preview.id) ? ' boss-silhouette' : ''}`}
+                  src={preview.imageUrl}
+                  alt={preview.label}
                 />
               )}
             </For>

--- a/src/dungeon/DungeonSortieConfig.test.ts
+++ b/src/dungeon/DungeonSortieConfig.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  BossTier,
+  PilotBossEntry,
+  PilotDungeonBoss,
+  WildBossEntry,
+  WildDungeonBoss,
+} from './DungeonSortieConfig';
+
+describe('BossTier with PilotBossEntry', () => {
+  it('resolve returns a PilotDungeonBoss', () => {
+    const tier = new BossTier([new PilotBossEntry('bandit1')]);
+    const boss = tier.resolve();
+    expect(boss).toBeInstanceOf(PilotDungeonBoss);
+  });
+
+  it('getPreviews returns a preview per pilot', () => {
+    const tier = new BossTier([new PilotBossEntry('bandit1'), new PilotBossEntry('bul')]);
+    const previews = tier.getPreviews();
+    expect(previews).toHaveLength(2);
+    expect(previews[0].id).toBe('bandit1');
+    expect(previews[1].id).toBe('bul');
+  });
+});
+
+describe('BossTier with WildBossEntry', () => {
+  it('resolve returns a WildDungeonBoss', () => {
+    const tier = new BossTier([new WildBossEntry({ id: 'gator', level: 10 })]);
+    const boss = tier.resolve();
+    expect(boss).toBeInstanceOf(WildDungeonBoss);
+    expect((boss as WildDungeonBoss).zoidData.id).toBe('gator');
+  });
+
+  it('getPreviews returns a preview per zoid', () => {
+    const tier = new BossTier([new WildBossEntry({ id: 'gator', level: 10 })]);
+    const previews = tier.getPreviews();
+    expect(previews).toHaveLength(1);
+    expect(previews[0].id).toBe('gator');
+    expect(previews[0].label).toBe('Gator');
+  });
+});
+
+describe('BossTier with mixed entries', () => {
+  it('getPreviews returns previews for both pilots and zoids', () => {
+    const tier = new BossTier([
+      new PilotBossEntry('bandit1'),
+      new WildBossEntry({ id: 'gator', level: 10 }),
+    ]);
+    const previews = tier.getPreviews();
+    expect(previews).toHaveLength(2);
+    expect(previews[0].isZoid).toBe(false);
+    expect(previews[1].isZoid).toBe(true);
+  });
+
+  it('resolve returns either PilotDungeonBoss or WildDungeonBoss', () => {
+    const tier = new BossTier([
+      new PilotBossEntry('bandit1'),
+      new WildBossEntry({ id: 'gator', level: 10 }),
+    ]);
+    const boss = tier.resolve();
+    expect(boss instanceof PilotDungeonBoss || boss instanceof WildDungeonBoss).toBe(true);
+  });
+});

--- a/src/dungeon/DungeonSortieConfig.ts
+++ b/src/dungeon/DungeonSortieConfig.ts
@@ -1,14 +1,106 @@
 import type { Drop } from '../item/Drop';
-import type { ZoidBlueprint } from '../models/Zoid';
+import type { Pilot } from '../models/Pilot';
+import { getPilotImage, PILOTS } from '../models/Pilot';
+import { getZoidById, getZoidImage, type ZoidBlueprint } from '../models/Zoid';
 import type { Requirement } from '../requirement';
 
-export interface BossTier {
-  pilots: string[];
-  requirements?: Requirement[];
+export interface BossPreview {
+  id: string;
+  imageUrl: string;
+  isZoid: boolean;
+  label: string;
 }
 
 export interface DungeonEnemy {
   itemDrops?: Drop[];
   requirement?: Requirement;
   zoidData: ZoidBlueprint;
+}
+
+export abstract class DungeonBoss {}
+
+export class PilotDungeonBoss extends DungeonBoss {
+  pilot: Pilot;
+
+  constructor(pilot: Pilot) {
+    super();
+    this.pilot = pilot;
+  }
+}
+
+export class WildDungeonBoss extends DungeonBoss {
+  zoidData: ZoidBlueprint;
+
+  constructor(zoidData: ZoidBlueprint) {
+    super();
+    this.zoidData = zoidData;
+  }
+}
+
+export abstract class BossEntry {
+  abstract getPreview(): BossPreview;
+  abstract resolve(): DungeonBoss;
+}
+
+export class PilotBossEntry extends BossEntry {
+  pilotId: string;
+
+  constructor(pilotId: string) {
+    super();
+    this.pilotId = pilotId;
+  }
+
+  getPreview(): BossPreview {
+    return {
+      id: this.pilotId,
+      imageUrl: getPilotImage(this.pilotId),
+      isZoid: false,
+      label: PILOTS[this.pilotId]?.name ?? this.pilotId,
+    };
+  }
+
+  resolve(): PilotDungeonBoss {
+    return new PilotDungeonBoss(PILOTS[this.pilotId]);
+  }
+}
+
+export class WildBossEntry extends BossEntry {
+  zoidData: ZoidBlueprint;
+
+  constructor(zoidData: ZoidBlueprint) {
+    super();
+    this.zoidData = zoidData;
+  }
+
+  getPreview(): BossPreview {
+    return {
+      id: this.zoidData.id,
+      imageUrl: getZoidImage(this.zoidData.id, this.zoidData.imageOverride),
+      isZoid: true,
+      label: getZoidById(this.zoidData.id).name,
+    };
+  }
+
+  resolve(): WildDungeonBoss {
+    return new WildDungeonBoss(this.zoidData);
+  }
+}
+
+export class BossTier {
+  entries: BossEntry[];
+  requirements?: Requirement[];
+
+  constructor(entries: BossEntry[], requirements?: Requirement[]) {
+    this.entries = entries;
+    this.requirements = requirements;
+  }
+
+  getPreviews(): BossPreview[] {
+    return this.entries.map((e) => e.getPreview());
+  }
+
+  resolve(): DungeonBoss {
+    const entry = this.entries[Math.floor(Math.random() * this.entries.length)];
+    return entry.resolve();
+  }
 }

--- a/src/dungeon/DungeonSortieEvent.test.ts
+++ b/src/dungeon/DungeonSortieEvent.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  BossTier,
+  PilotBossEntry,
+  PilotDungeonBoss,
+  WildBossEntry,
+  WildDungeonBoss,
+} from './DungeonSortieConfig';
+import { DungeonEvent, DungeonEventChoice, HealOutcome } from './DungeonEventOutcome';
+import { DungeonSortieEvent } from './DungeonSortieEvent';
+
+const DUMMY_EVENT = new DungeonEvent('e1', 'test', [new DungeonEventChoice('ok', new HealOutcome('heal', 10))]);
+
+function makeSortie(bossTiers: BossTier[]): DungeonSortieEvent {
+  return new DungeonSortieEvent({
+    baseReward: { magnis: 100 },
+    bossTiers,
+    eliteEnemies: [],
+    enemies: [{ zoidData: { id: 'gator', level: 1 } }],
+    entryCost: 0,
+    eventPool: [DUMMY_EVENT],
+    id: 'test_sortie',
+    layers: 2,
+    nodesPerLayer: [2, 3],
+    supplyOptions: [],
+  });
+}
+
+describe('DungeonSortieEvent', () => {
+  it('resolveBoss returns PilotDungeonBoss for pilot entry', () => {
+    const sortie = makeSortie([new BossTier([new PilotBossEntry('bandit1')])]);
+    expect(sortie.resolveBoss()).toBeInstanceOf(PilotDungeonBoss);
+  });
+
+  it('resolveBoss returns WildDungeonBoss for wild entry', () => {
+    const sortie = makeSortie([new BossTier([new WildBossEntry({ id: 'gator', level: 20 })])]);
+    expect(sortie.resolveBoss()).toBeInstanceOf(WildDungeonBoss);
+  });
+
+  it('getPossibleBosses returns previews from active tier', () => {
+    const sortie = makeSortie([new BossTier([new WildBossEntry({ id: 'gator', level: 20 })])]);
+    const previews = sortie.getPossibleBosses();
+    expect(previews).toHaveLength(1);
+    expect(previews[0].id).toBe('gator');
+    expect(previews[0].label).toBe('Gator');
+  });
+});

--- a/src/dungeon/DungeonSortieEvent.ts
+++ b/src/dungeon/DungeonSortieEvent.ts
@@ -1,12 +1,10 @@
 import { t } from '../i18n';
 import type { Drop } from '../item/Drop';
 import type { CurrencyReward } from '../models/Currency';
-import type { Pilot } from '../models/Pilot';
-import { PILOTS } from '../models/Pilot';
 import type { Requirement } from '../requirement';
 import type { CityAction } from '../landmark/action/CityAction';
 import type { DungeonEvent } from './DungeonEventOutcome';
-import type { BossTier, DungeonEnemy } from './DungeonSortieConfig';
+import type { BossPreview, BossTier, DungeonBoss, DungeonEnemy } from './DungeonSortieConfig';
 import type { SupplyOption } from './DungeonSupply';
 
 export interface DungeonSortieConfig {
@@ -73,19 +71,21 @@ export class DungeonSortieEvent implements CityAction {
     return this.requirements?.every((r) => r.isCompleted()) ?? true;
   }
 
-  getPossibleBosses(): string[] {
+  getPossibleBosses(): BossPreview[] {
+    return this.getActiveTier().getPreviews();
+  }
+
+  resolveBoss(): DungeonBoss {
+    return this.getActiveTier().resolve();
+  }
+
+  private getActiveTier(): BossTier {
     let activeTier = this.bossTiers[0];
     for (const tier of this.bossTiers) {
       if (tier.requirements?.every((r) => r.isCompleted()) ?? true) {
         activeTier = tier;
       }
     }
-    return activeTier.pilots;
-  }
-
-  resolveBoss(): Pilot {
-    const pilots = this.getPossibleBosses();
-    const pilotId = pilots[Math.floor(Math.random() * pilots.length)];
-    return PILOTS[pilotId];
+    return activeTier;
   }
 }

--- a/src/dungeon/dungeon.css
+++ b/src/dungeon/dungeon.css
@@ -222,6 +222,10 @@
   width: 32px;
 }
 
+.boss-silhouette {
+  filter: brightness(0) drop-shadow(0 0 3px rgb(233 69 96 / 60%));
+}
+
 /* Buff stats */
 .dungeon-buffs {
   display: flex;
@@ -491,11 +495,11 @@
 }
 
 .sortie-boss-img {
-  height: 32px;
+  height: 40px;
   image-rendering: pixelated;
   object-fit: contain;
   opacity: 0.8;
-  width: 32px;
+  width: 40px;
 }
 
 .sortie-boss-previews {
@@ -506,9 +510,12 @@
 
 .sortie-boss-section {
   align-items: center;
+  background: rgb(0 0 0 / 60%);
+  border-radius: 6px;
   display: flex;
   gap: 0.4rem;
   margin-top: 0.5rem;
+  padding: 0.3rem 0.6rem;
 }
 
 .sortie-btn:disabled {

--- a/src/dungeon/dungeonStore.ts
+++ b/src/dungeon/dungeonStore.ts
@@ -1,6 +1,6 @@
 import { createMemo, createSignal } from 'solid-js';
-import type { Pilot } from '../models/Pilot';
 import { emitRewardEvent, setPlayerStats } from '../store/gameStore';
+import type { DungeonBoss } from './DungeonSortieConfig';
 import { Currency } from '../models/Currency';
 import { addCurrency } from '../store/walletStore';
 import type { DungeonSortieEvent } from './DungeonSortieEvent';
@@ -22,7 +22,7 @@ export const DungeonPhase = {
 export type DungeonPhase = (typeof DungeonPhase)[keyof typeof DungeonPhase];
 
 export interface DungeonRunState {
-  bossPilot: Pilot;
+  boss: DungeonBoss;
   config: DungeonSortieEvent;
   currentDepth: number;
   currentNodeId: string | null;
@@ -153,7 +153,7 @@ function startSortie(config: DungeonSortieEvent, playerHealth: number, playerMax
   resetBuffs();
   const graph = generateSortie({ layers: config.layers, nodesPerLayer: config.nodesPerLayer });
   setDungeonRun({
-    bossPilot: config.resolveBoss(),
+    boss: config.resolveBoss(),
     config,
     currentDepth: 1,
     currentNodeId: null,

--- a/src/game/BaseBattle.ts
+++ b/src/game/BaseBattle.ts
@@ -1,6 +1,5 @@
 import { BATTLE_TICK, CLICK_COOLDOWN, TICK_TIME } from '../constants';
 import { awardExperience, calculateExperienceGain } from '../models/Experience';
-import type { PlayerStats } from '../models/Player';
 import { getOwnedZoidLevel, getZoidById, type SpawnedZoid, ZoidResearchStatus } from '../models/Zoid';
 import {
   damageEvents,
@@ -27,11 +26,6 @@ export abstract class BaseBattle {
   counter = 0;
   enemy!: SpawnedZoid;
   lastClickAttack = 0;
-  playerStats: PlayerStats;
-
-  constructor(playerStats: PlayerStats) {
-    this.playerStats = playerStats;
-  }
 
   clickAttack(): void {
     const now = Date.now();

--- a/src/game/Battle.ts
+++ b/src/game/Battle.ts
@@ -2,7 +2,6 @@ import type { Route } from '../landmark';
 import { randomEnemy } from '../landmark';
 import { buildDropPool, rollDrops } from '../item/rollDrops';
 import { grantCurrencyReward } from '../store/walletStore';
-import type { PlayerStats } from '../models/Player';
 import { getZoidById, spawnZoid } from '../models/Zoid';
 import { checkCampaigns } from '../store/campaignStore';
 import { emitRewardEvent, setEnemyZoid } from '../store/gameStore';
@@ -17,8 +16,8 @@ import { BaseBattle } from './BaseBattle';
 export class Battle extends BaseBattle {
   route: Route;
 
-  constructor(playerStats: PlayerStats, route: Route) {
-    super(playerStats);
+  constructor(route: Route) {
+    super();
     this.route = route;
     this.enemy = spawnZoid(randomEnemy(route));
     updateZoidResearch(this.enemy.id, ZoidResearchStatus.Seen);

--- a/src/game/DuelBattle.ts
+++ b/src/game/DuelBattle.ts
@@ -63,7 +63,7 @@ export class DuelBattle extends BaseBattle {
   enemyZoids: ZoidBlueprint[];
 
   constructor(playerStats: PlayerStats, pilot: Pilot) {
-    super(playerStats);
+    super();
     this.pilot = pilot;
     this.enemyZoids = getActiveZoids(pilot);
     this.playerZoid = findStrongestZoid();

--- a/src/game/Game.test.ts
+++ b/src/game/Game.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest';
 
+import { BossTier, PilotBossEntry } from '../dungeon/DungeonSortieConfig';
 import { DungeonSortieEvent } from '../dungeon/DungeonSortieEvent';
 import { dungeonRun, endDungeon, startSortie } from '../dungeon/dungeonStore';
 import { DungeonEvent, DungeonEventChoice, HealOutcome } from '../dungeon/DungeonEventOutcome';
@@ -10,7 +11,7 @@ const DUMMY_EVENT = new DungeonEvent('e1', 'test', [new DungeonEventChoice('ok',
 
 const DUMMY_SORTIE = new DungeonSortieEvent({
   baseReward: { magnis: 100 },
-  bossTiers: [{ pilots: ['bandit1'] }],
+  bossTiers: [new BossTier([new PilotBossEntry('bandit1')])],
   eliteEnemies: [],
   enemies: [{ zoidData: { id: 'gator', level: 1 } }],
   entryCost: 0,

--- a/src/game/Game.ts
+++ b/src/game/Game.ts
@@ -1,6 +1,7 @@
 import { TICK_TIME } from '../constants';
 import { CAMPAIGNS } from '../campaign/campaigns';
 import { DungeonBattle } from '../dungeon/DungeonBattle';
+import { PilotDungeonBoss, WildDungeonBoss } from '../dungeon/DungeonSortieConfig';
 import { DungeonSortieEvent } from '../dungeon/DungeonSortieEvent';
 import {
   advanceLayer,
@@ -50,6 +51,7 @@ import {
   setDuelState,
   showPopup,
   setRewardEvents,
+  playerStats,
 } from '../store/gameStore';
 import { setCurrentLandmark } from '../store/landmarkStore';
 import { addZoidToArmy, partyMaxHealth, setParty } from '../store/partyStore';
@@ -153,7 +155,7 @@ export class Game {
   }
 
   enterDuelBattle(pilot: Pilot): void {
-    const battle = new DuelBattle(DEFAULT_PLAYER, pilot);
+    const battle = new DuelBattle(playerStats()!, pilot);
     battle.onDefeat = () => {
       this.endDuelBattle(new PopupMessage(t('ui:not_strong_enough', { name: t(`pilots:${pilot.id}`) }), t('ui:defeated'), PopupType.Defeat));
     };
@@ -168,7 +170,7 @@ export class Game {
   }
 
   enterPilotBattle(pilot: Pilot, unwinnable = false, reward?: Reward): void {
-    const battle = new PilotBattle(DEFAULT_PLAYER, pilot);
+    const battle = new PilotBattle(playerStats()!, pilot);
     battle.onDefeat = () => {
       if (unwinnable) {
         incrementPilotDefeats(pilot.id);
@@ -294,17 +296,21 @@ export class Game {
   private startDungeonBoss(): void {
     const run = dungeonRun();
     if (!run) {return;}
-    const boss = run.bossPilot;
-    const battle = new PilotBattle(
-      DEFAULT_PLAYER,
-      boss,
-      run.playerHealth,
-      run.playerMaxHealth
-    );
+    const boss = run.boss;
+    if (boss instanceof PilotDungeonBoss) {
+      this.startPilotDungeonBoss(boss, run.playerHealth, run.playerMaxHealth);
+    } else if (boss instanceof WildDungeonBoss) {
+      this.startWildDungeonBoss(run.config);
+    }
+  }
+
+  private startPilotDungeonBoss(boss: PilotDungeonBoss, playerHealth: number, playerMaxHealth: number): void {
+    const { pilot } = boss;
+    const battle = new PilotBattle(playerStats()!, pilot, playerHealth, playerMaxHealth);
     battle.onVictory = () => {
-      addCurrency(Currency.Magnis, boss.magnisReward);
-      emitRewardEvent(boss.magnisReward, 'magnis');
-      incrementPilotDefeats(boss.id);
+      addCurrency(Currency.Magnis, pilot.magnisReward);
+      emitRewardEvent(pilot.magnisReward, 'magnis');
+      incrementPilotDefeats(pilot.id);
       this.completeDungeonNode();
     };
     battle.onDefeat = () => {
@@ -315,8 +321,19 @@ export class Game {
     setDungeonPhase(DungeonPhase.Boss);
   }
 
+  private startWildDungeonBoss(config: DungeonSortieEvent): void {
+    const battle = new DungeonBattle(config, SortieNodeType.Boss);
+    battle.onNodeComplete = () => this.completeDungeonNode();
+    battle.onDefeat = () => {
+      this.endDungeonRun(false);
+    };
+    this.battle = battle;
+    setBattleState(BattleState.DungeonCombat);
+    setDungeonPhase(DungeonPhase.Boss);
+  }
+
   private startDungeonCombat(config: DungeonSortieEvent, nodeType: SortieNodeType): void {
-    const battle = new DungeonBattle(DEFAULT_PLAYER, config, nodeType);
+    const battle = new DungeonBattle(config, nodeType);
     battle.onNodeComplete = () => this.completeDungeonNode();
     battle.onDefeat = () => {
       this.endDungeonRun(false);
@@ -327,7 +344,7 @@ export class Game {
   }
 
   private startBattle(route: Route): void {
-    this.battle = new Battle(DEFAULT_PLAYER, route);
+    this.battle = new Battle(route);
     setBattleState(BattleState.WildCombat);
   }
 

--- a/src/game/PilotBattle.ts
+++ b/src/game/PilotBattle.ts
@@ -24,7 +24,7 @@ export class PilotBattle extends BaseBattle {
   zoids: ZoidBlueprint[];
 
   constructor(playerStats: PlayerStats, pilot: Pilot, initialHealth?: number, initialMaxHealth?: number) {
-    super(playerStats);
+    super();
     this.pilot = pilot;
     this.zoids = getActiveZoids(pilot);
     this.playerMaxHealth = initialMaxHealth ?? (playerStats.baseHealth + partyMaxHealth());

--- a/src/landmark/Dungeon.ts
+++ b/src/landmark/Dungeon.ts
@@ -1,7 +1,7 @@
 import { CAMPAIGNS } from '../campaign/campaigns';
 import { DungeonSortieEvent } from '../dungeon/DungeonSortieEvent';
 import { DUNGEON_EVENTS } from '../dungeon/dungeonEvents';
-import type { BossTier } from '../dungeon/DungeonSortieConfig';
+import { BossTier, PilotBossEntry, WildBossEntry } from '../dungeon/DungeonSortieConfig';
 import { DUNGEON_SUPPLIES } from '../dungeon/dungeonSupplies';
 import { ItemDrop } from '../item';
 import { MissionCompletedRequirement, PilotDefeatRequirement, RouteKillRequirement } from '../requirement';
@@ -26,10 +26,10 @@ export const DUNGEONS: Dungeon[] = [
         id: 'elmia_ruins_sortie',
         itemDrops: [new ItemDrop('core_preserver', 10)],
         bossTiers: [
-          { pilots: ['bul'] },
-          { pilots: ['bianco_nero'], requirements: [new MissionCompletedRequirement(C.id, 'find_van')] },
-          { pilots: ['bianco_nero', 'bul'], requirements: [new MissionCompletedRequirement(C.id, 'defeat_bianco_nero')] },
-        ] satisfies BossTier[],
+          new BossTier([new PilotBossEntry('bul')]),
+          new BossTier([new PilotBossEntry('bianco_nero')], [new MissionCompletedRequirement(C.id, 'find_van')]),
+          new BossTier([new PilotBossEntry('bianco_nero'), new PilotBossEntry('bul')], [new MissionCompletedRequirement(C.id, 'defeat_bianco_nero')]),
+        ],
         enemies: [
           { zoidData: { attackOverride: 1, id: 'gator', level: 14, maxHealthOverride: 80 } },
           { zoidData: { attackOverride: 1, id: 'malder', level: 12, maxHealthOverride: 100 } },
@@ -70,15 +70,16 @@ export const DUNGEONS: Dungeon[] = [
         id: 'tauros_grotto_sortie',
         itemDrops: [new ItemDrop('core_preserver', 10)],
         bossTiers: [
-          { pilots: ['arcadia_guard'] },
-        ] satisfies BossTier[],
+          new BossTier([new WildBossEntry({ id: 'sinker', level: 40, maxHealthOverride: 2000, attackOverride: 20 })]),
+        ],
         enemies: [
           { zoidData: { attackOverride: 10, id: 'gorgodos', level: 24, maxHealthOverride: 500 } },
           { zoidData: { attackOverride: 15, id: 'gunbeetle', level: 24, maxHealthOverride: 400 } },
           { zoidData: { attackOverride: 12, id: 'gator', level: 25, maxHealthOverride: 480 } },
         ],
         eliteEnemies: [
-          { zoidData: { id: 'sinker', level: 30, maxHealthOverride: 400 } },
+          { zoidData: { id: 'giraffsworder', level: 30, maxHealthOverride: 800 } },
+          { zoidData: { id: 'gunbeetle', level: 30, maxHealthOverride: 800 } },
         ],
         baseReward: { magnis: 300, zi_metal: 10 },
         entryCost: 30,

--- a/src/models/Zoid.ts
+++ b/src/models/Zoid.ts
@@ -59,7 +59,7 @@ export const ZOID_LIST: Record<string, ZoidSpecies> = {
   elephantus: { id: 'elephantus', name: 'Elephantus', attack: 100, maxHealth: 200, baseExp: 15, scanRate: -1, price: 50000, faction: Faction.HelicRepublic, levelType: LevelType.MediumSlow },
   garius: { id: 'garius', name: 'Garius', attack: 50, maxHealth: 100, baseExp: 10, scanRate: -1, price: 2000, faction: Faction.HelicRepublic, levelType: LevelType.Fast },
   gator: { id: 'gator', name: 'Gator', attack: 150, maxHealth: 200, baseExp: 35, scanRate: 60, price: 4000, faction: Faction.GuylosEmpire, levelType: LevelType.MediumFast },
-  giraffsworder: { id: 'giraffsworder', name: 'Giraffsworder', attack: 180, maxHealth: 150, baseExp: 35, scanRate: 40, price: 5000, faction: Faction.Neutral, levelType: LevelType.Fast },
+  giraffsworder: { id: 'giraffsworder', name: 'Girafsworder', attack: 180, maxHealth: 150, baseExp: 35, scanRate: 40, price: 5000, faction: Faction.Neutral, levelType: LevelType.Fast },
   glidoler: { id: 'glidoler', name: 'Glidoler', attack: 100, maxHealth: 40, baseExp: 10, scanRate: -1, price: 2000, faction: Faction.HelicRepublic, levelType: LevelType.MediumFast },
   gorgodos: { id: 'gorgodos', name: 'Gorgodos', attack: 140, maxHealth: 400, baseExp: 50, scanRate: 20, price: 12000, faction: Faction.HelicRepublic, levelType: LevelType.Slow },
   gunbeetle: { id: 'gunbeetle', name: 'Gunbeetle', attack: 120, maxHealth: 200, baseExp: 35, scanRate: 40, price: 5000, faction: Faction.Neutral, levelType: LevelType.Fast },

--- a/src/story/IntroBattle.ts
+++ b/src/story/IntroBattle.ts
@@ -1,5 +1,4 @@
 import { BaseBattle } from '../game/BaseBattle';
-import type { PlayerStats } from '../models/Player';
 import { spawnZoid, buildZoid } from '../models/Zoid';
 import { setEnemyZoid } from '../store/gameStore';
 
@@ -8,8 +7,8 @@ const STARTER_LEVEL = 5;
 export class IntroBattle extends BaseBattle {
   onVictory: (() => void) | null = null;
 
-  constructor(playerStats: PlayerStats, zoidId: string) {
-    super(playerStats);
+  constructor(zoidId: string) {
+    super();
     this.enemy = spawnZoid(buildZoid({ id: zoidId, level: STARTER_LEVEL, maxHealthOverride: 100 }));
     this.syncToStore();
   }

--- a/src/story/IntroSequence.tsx
+++ b/src/story/IntroSequence.tsx
@@ -1,7 +1,6 @@
 import { createSignal, Match, onCleanup, Switch, type Component } from 'solid-js';
 import { TICK_TIME } from '../constants';
 import { GameLoop } from '../game/GameLoop';
-import { DEFAULT_PLAYER } from '../models/Player';
 import { getZoidById } from '../models/Zoid';
 import { BattleState, setBattleState } from '../store/gameStore';
 import BattleScreen from '../ui/BattleScreen';
@@ -30,7 +29,7 @@ const IntroSequence: Component<IntroSequenceProps> = (props) => {
   };
 
   const handleStartBattle = () => {
-    battle = new IntroBattle(DEFAULT_PLAYER, selectedZoidId!);
+    battle = new IntroBattle(selectedZoidId!);
     battle.onVictory = () => {
       loop?.stop();
       setBattleState(BattleState.Idle);

--- a/src/ui/IdleLandmarkScreen.tsx
+++ b/src/ui/IdleLandmarkScreen.tsx
@@ -3,7 +3,8 @@ import { DungeonSortieEvent } from '../dungeon/DungeonSortieEvent';
 import '../dungeon/dungeon.css';
 import { t } from '../i18n';
 import { Currency } from '../models/Currency';
-import { getPilotImage } from '../models/Pilot';
+import type { BossPreview } from '../dungeon/DungeonSortieConfig';
+import { getZoidResearch } from '../store/zoidResearchStore';
 import type { City, CityAction } from '../landmark';
 import { ActionDuelPilot, ActionVisitDepot, ActionVisitLab, isCityActionVisible } from '../landmark';
 import { currentLandmark, landmarkBackground } from '../store/landmarkStore';
@@ -42,8 +43,12 @@ const IdleLandmarkScreen: Component = () => {
                 <div class="sortie-boss-section">
                   <span class="dungeon-boss-title">{t('dungeon:possible_bosses')}</span>
                   <For each={action().getPossibleBosses()}>
-                    {(pilotId) => (
-                      <img class="sortie-boss-img" src={getPilotImage(pilotId)} alt={pilotId} />
+                    {(preview: BossPreview) => (
+                      <img
+                        class={`sortie-boss-img${preview.isZoid && !getZoidResearch(preview.id) ? ' boss-silhouette' : ''}`}
+                        src={preview.imageUrl}
+                        alt={preview.label}
+                      />
                     )}
                   </For>
                 </div>

--- a/test/Battle.test.ts
+++ b/test/Battle.test.ts
@@ -26,7 +26,7 @@ describe('Battle', () => {
   });
 
   it('should not deal auto-damage with empty party', () => {
-    const battle = new Battle(DEFAULT_PLAYER, toughRoute);
+    const battle = new Battle(toughRoute);
     const initialHealth = battle.enemy.health;
     const ticksNeeded = BATTLE_TICK / TICK_TIME;
 
@@ -39,7 +39,7 @@ describe('Battle', () => {
   });
 
   it('should auto-attack after accumulating BATTLE_TICK', () => {
-    const battle = new Battle(DEFAULT_PLAYER, toughRoute);
+    const battle = new Battle(toughRoute);
     const initialHealth = battle.enemy.health;
     const ticksNeeded = BATTLE_TICK / TICK_TIME;
 
@@ -51,7 +51,7 @@ describe('Battle', () => {
   });
 
   it('should not auto-attack before BATTLE_TICK', () => {
-    const battle = new Battle(DEFAULT_PLAYER, toughRoute);
+    const battle = new Battle(toughRoute);
     const initialHealth = battle.enemy.health;
     const ticksNeeded = BATTLE_TICK / TICK_TIME;
 
@@ -63,7 +63,7 @@ describe('Battle', () => {
   });
 
   it('should deal click damage using player click attack', () => {
-    const battle = new Battle(DEFAULT_PLAYER, toughRoute);
+    const battle = new Battle(toughRoute);
     const initialHealth = battle.enemy.health;
 
     battle.clickAttack();
@@ -72,7 +72,7 @@ describe('Battle', () => {
   });
 
   it('should rate-limit click attacks', () => {
-    const battle = new Battle(DEFAULT_PLAYER, toughRoute);
+    const battle = new Battle(toughRoute);
     const initialHealth = battle.enemy.health;
 
     battle.clickAttack();
@@ -82,7 +82,7 @@ describe('Battle', () => {
   });
 
   it('should calculate click and auto damage independently', () => {
-    const battle = new Battle(DEFAULT_PLAYER, toughRoute);
+    const battle = new Battle(toughRoute);
     const initialHealth = battle.enemy.health;
 
     battle.clickAttack();
@@ -97,7 +97,7 @@ describe('Battle', () => {
   });
 
   it('should auto-spawn new enemy when enemy health reaches 0', () => {
-    const battle = new Battle(DEFAULT_PLAYER, ROUTES[0]);
+    const battle = new Battle(ROUTES[0]);
     battle.enemy.health = 1;
 
     battle.clickAttack();
@@ -106,7 +106,7 @@ describe('Battle', () => {
   });
 
   it('should spawn enemy with full health', () => {
-    const battle = new Battle(DEFAULT_PLAYER, ROUTES[0]);
+    const battle = new Battle(ROUTES[0]);
 
     battle.spawnEnemy();
 
@@ -115,13 +115,13 @@ describe('Battle', () => {
   });
 
   it('should mark enemy zoid as seen on construction', () => {
-    const battle = new Battle(DEFAULT_PLAYER, ROUTES[0]);
+    const battle = new Battle(ROUTES[0]);
 
     expect(getZoidResearch(battle.enemy.id)).toBe(ZoidResearchStatus.Seen);
   });
 
   it('should mark enemy zoid as seen on spawn', () => {
-    const battle = new Battle(DEFAULT_PLAYER, ROUTES[0]);
+    const battle = new Battle(ROUTES[0]);
     loadZoidResearch({});
 
     battle.spawnEnemy();
@@ -130,7 +130,7 @@ describe('Battle', () => {
   });
 
   it('should increment route kills when enemy is defeated', () => {
-    const battle = new Battle(DEFAULT_PLAYER, ROUTES[0]);
+    const battle = new Battle(ROUTES[0]);
     battle.enemy.health = 1;
 
     battle.clickAttack();


### PR DESCRIPTION
## Summary
- Wild zoids can now be dungeon bosses (scannable, with 5x reward multiplier)
- Boss previews show silhouettes for unseen wild zoids based on research status
- `BossTier` supports mixed pilot and wild zoid entries via `BossEntry` class hierarchy (`PilotBossEntry`, `WildBossEntry`)
- Added Sinker as test wild boss in Tauros Grotto
- `BaseBattle` no longer takes unused `playerStats` constructor param; `DuelBattle` and `PilotBattle` now receive real player stats from store

## Test plan
- [x] Unit tests for `BossTier` with pilot, wild, and mixed entries
- [x] Unit tests for `DungeonSortieEvent.resolveBoss()` and `getPossibleBosses()`
- [ ] Browser: enter Tauros Grotto sortie, verify wild boss fight with scanning
- [ ] Browser: verify boss preview silhouettes for unseen zoids
- [ ] Browser: verify Elmia Ruins pilot bosses still work

Closes #46