### PR TITLE
Save scan newOnly state and gate faction actions to dev (#149)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zoids-sleeper",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zoids-sleeper",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "dependencies": {
         "i18next": "^26.0.3",
         "solid-js": "^1.9.11"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zoids-sleeper",
   "private": true,
-  "version": "0.4.3",
+  "version": "0.4.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/game/migrations.ts
+++ b/src/game/migrations.ts
@@ -7,6 +7,7 @@ export type MigrationData = Partial<SaveData> & Record<string, unknown>;
 type MigrationFn = (data: MigrationData) => void;
 
 const migrations: Record<string, MigrationFn> = {
+  '0.4.4': () => {},
   '0.4.3': (data) => {
     const stats = data.playerStats as Record<string, unknown> | undefined;
     if (stats && !stats.faction) {

--- a/src/game/shouldSkipScan.test.ts
+++ b/src/game/shouldSkipScan.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { ZoidResearchStatus } from '../models/Zoid';
-import { toggleScanNewOnly, scanNewOnly } from '../store/scanStore';
+import { loadScanSetup, ScanMode, toggleScanNewOnly, scanNewOnly } from '../store/scanStore';
 import { incrementZoidData } from '../store/zoidDataStore';
 import { updateZoidResearch } from '../store/zoidResearchStore';
 import { shouldSkipScan } from './BaseBattle';
@@ -16,18 +16,21 @@ describe('shouldSkipScan', () => {
   });
 
   it('returns false when scanNewOnly is on and zoid is only Sighted with no Zi Data', () => {
+    loadScanSetup({ deviceId: 'core_preserver', mode: ScanMode.Permanent, newOnly: false });
     toggleScanNewOnly();
     updateZoidResearch('merda', ZoidResearchStatus.Seen);
     expect(shouldSkipScan('merda')).toBe(false);
   });
 
   it('returns true when scanNewOnly is on and zoid has Zi Data', () => {
+    loadScanSetup({ deviceId: 'core_preserver', mode: ScanMode.Permanent, newOnly: false });
     toggleScanNewOnly();
     incrementZoidData('gator');
     expect(shouldSkipScan('gator')).toBe(true);
   });
 
   it('returns true when scanNewOnly is on and zoid status is Created', () => {
+    loadScanSetup({ deviceId: 'core_preserver', mode: ScanMode.Permanent, newOnly: false });
     toggleScanNewOnly();
     updateZoidResearch('molga', ZoidResearchStatus.Created);
     expect(shouldSkipScan('molga')).toBe(true);

--- a/src/landmark/City.ts
+++ b/src/landmark/City.ts
@@ -1,7 +1,7 @@
 import { CUTSCENES } from '../cutscene';
 import { type ConsumableItem, ITEMS } from '../item';
 import { PILOTS } from '../models/Pilot';
-import { COMPOUND_REQUIREMENTS, ImpossibleRequirement, ItemRequirement, MissionCompletedRequirement, NpcTalkedInCampaignRequirement, PilotDefeatRequirement, RouteKillRequirement } from '../requirement';
+import { COMPOUND_REQUIREMENTS, DevRequirement, ImpossibleRequirement, ItemRequirement, MissionCompletedRequirement, NpcTalkedInCampaignRequirement, PilotDefeatRequirement, RouteKillRequirement } from '../requirement';
 import { activateCityActionReward, itemReward, missionAdvanceReward } from '../reward';
 import { ActionDuelPilot } from './action/ActionDuelPilot';
 import { ActionFightPilot } from './action/ActionFightPilot';
@@ -24,7 +24,7 @@ const S = 'shells_of_time';
 
 const AUTOMATIC_ACTIONS: Record<string, CityAction[]> = {
   arthur_talk_fight_decide: (() => {
-    const requirements = [new MissionCompletedRequirement(C, 'deliver_girl')];
+    const requirements = [new DevRequirement(), new MissionCompletedRequirement(C, 'deliver_girl')];
     const completeRequirements = [new PilotDefeatRequirement('arthur')];
     const hidden = [new ImpossibleRequirement()];
     const decision = new ActionTalkToNPC('arthur', [new PilotDefeatRequirement('arthur')]);
@@ -33,7 +33,7 @@ const AUTOMATIC_ACTIONS: Record<string, CityAction[]> = {
     return [intro, fight, decision];
   })(),
   concho_talk_fight_decide: (() => {
-    const requirements = [new MissionCompletedRequirement(C, 'deliver_girl')];
+    const requirements = [new DevRequirement(), new MissionCompletedRequirement(C, 'deliver_girl')];
     const completeRequirements = [new PilotDefeatRequirement('concho_cancer')];
     const hidden = [new ImpossibleRequirement()];
     const decision = new ActionTalkToNPC('concho_cancer', [new PilotDefeatRequirement('concho_cancer')]);

--- a/src/store/scanStore.test.ts
+++ b/src/store/scanStore.test.ts
@@ -9,6 +9,7 @@ describe('scanStore', () => {
     });
 
     it('toggles to true and back', () => {
+      loadScanSetup({ deviceId: 'core_preserver', mode: ScanMode.Permanent, newOnly: false });
       toggleScanNewOnly();
       expect(scanNewOnly()).toBe(true);
       toggleScanNewOnly();
@@ -18,15 +19,15 @@ describe('scanStore', () => {
 
   describe('loadScanSetup', () => {
     it('restores active scan from saved data', () => {
-      loadScanSetup({ deviceId: 'core_preserver', mode: ScanMode.Permanent });
+      loadScanSetup({ deviceId: 'core_preserver', mode: ScanMode.Permanent, newOnly: false });
 
-      expect(activeScan()).toEqual({ deviceId: 'core_preserver', mode: ScanMode.Permanent });
+      expect(activeScan()).toEqual({ deviceId: 'core_preserver', mode: ScanMode.Permanent, newOnly: false });
     });
   });
 
   describe('resetScanAfterBattle', () => {
     it('clears single mode after battle', () => {
-      loadScanSetup({ deviceId: 'core_preserver', mode: ScanMode.Single });
+      loadScanSetup({ deviceId: 'core_preserver', mode: ScanMode.Single, newOnly: false });
 
       resetScanAfterBattle();
 
@@ -34,11 +35,11 @@ describe('scanStore', () => {
     });
 
     it('keeps permanent mode after battle even without stock', () => {
-      loadScanSetup({ deviceId: 'core_preserver', mode: ScanMode.Permanent });
+      loadScanSetup({ deviceId: 'core_preserver', mode: ScanMode.Permanent, newOnly: false });
 
       resetScanAfterBattle();
 
-      expect(activeScan()).toEqual({ deviceId: 'core_preserver', mode: ScanMode.Permanent });
+      expect(activeScan()).toEqual({ deviceId: 'core_preserver', mode: ScanMode.Permanent, newOnly: false });
     });
   });
 });

--- a/src/store/scanStore.ts
+++ b/src/store/scanStore.ts
@@ -6,10 +6,10 @@ export type ScanMode = (typeof ScanMode)[keyof typeof ScanMode];
 export interface ActiveScan {
   deviceId: string;
   mode: ScanMode;
+  newOnly: boolean;
 }
 
 const [activeScan, setActiveScan] = createSignal<ActiveScan | null>(null);
-const [scanNewOnly, setScanNewOnly] = createSignal(false);
 
 function getActiveDeviceId(): string | null {
   return activeScan()?.deviceId ?? null;
@@ -20,7 +20,7 @@ function getActiveScanMode(): ScanMode {
 }
 
 function loadScanSetup(data: ActiveScan): void {
-  setActiveScan(data);
+  setActiveScan({ ...data, newOnly: data.newOnly ?? false });
 }
 
 function resetScanAfterBattle(): void {
@@ -31,19 +31,25 @@ function resetScanAfterBattle(): void {
   }
 }
 
+function scanNewOnly(): boolean {
+  return activeScan()?.newOnly ?? false;
+}
+
 function toggleScanNewOnly(): void {
-  setScanNewOnly((prev) => !prev);
+  const current = activeScan();
+  if (!current) {return;}
+  setActiveScan({ ...current, newOnly: !current.newOnly });
 }
 
 function toggleScan(deviceId: string): void {
   const current = activeScan();
   if (!current || current.deviceId !== deviceId) {
-    setActiveScan({ deviceId, mode: ScanMode.Single });
+    setActiveScan({ deviceId, mode: ScanMode.Single, newOnly: current?.newOnly ?? false });
     return;
   }
   switch (current.mode) {
     case ScanMode.Single:
-      setActiveScan({ deviceId, mode: ScanMode.Permanent });
+      setActiveScan({ ...current, mode: ScanMode.Permanent });
       break;
     case ScanMode.Permanent:
       setActiveScan(null);

--- a/test/Save.test.ts
+++ b/test/Save.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Save } from '../src/game/Save';
 import { Currency } from '../src/models/Currency';
 import { DEFAULT_PARTY, ZoidResearchStatus } from '../src/models/Zoid';
-import { loadScanSetup, ScanMode } from '../src/store/scanStore';
+import { loadScanSetup, ScanMode, toggleScanNewOnly } from '../src/store/scanStore';
 import { incrementRouteKills, loadStatistics } from '../src/store/statisticsStore';
 import { addCurrency, loadWallet } from '../src/store/walletStore';
 import { loadZoidResearch, updateZoidResearch } from '../src/store/zoidResearchStore';
@@ -64,13 +64,24 @@ describe('Save', () => {
   });
 
   it('should persist scan setup', () => {
-    loadScanSetup({ deviceId: 'core_preserver', mode: ScanMode.Permanent });
+    loadScanSetup({ deviceId: 'core_preserver', mode: ScanMode.Permanent, newOnly: false });
     const save = new Save();
 
     save.store();
     const loaded = save.load();
 
-    expect(loaded?.scanSetup).toEqual({ deviceId: 'core_preserver', mode: ScanMode.Permanent });
+    expect(loaded?.scanSetup).toEqual({ deviceId: 'core_preserver', mode: ScanMode.Permanent, newOnly: false });
+  });
+
+  it('should persist scan new only', () => {
+    loadScanSetup({ deviceId: 'core_preserver', mode: ScanMode.Permanent, newOnly: false });
+    toggleScanNewOnly();
+    const save = new Save();
+
+    save.store();
+    const loaded = save.load();
+
+    expect(loaded?.scanSetup?.newOnly).toBe(true);
   });
 
   it('should persist route kills', () => {


### PR DESCRIPTION
## Summary
- Persist `newOnly` flag in `ActiveScan` so the "new only" checkbox state survives reloads
- Remove redundant `scanNewOnly` signal — derive it from `activeScan().newOnly` instead
- Gate Arthur and Concho city actions behind `DevRequirement` so they only appear in dev mode
- Bump version to 0.4.4 with no-op migration

Closes #149

## Test plan
- [x] All 366 tests pass
- [x] Enable "new only" checkbox, reload the game, verify it persists
- [x] Verify Arthur/Concho actions don't appear in production build