### PR TITLE
Show enemy probability on route info panel

### DIFF
--- a/src/landmark/Route.ts
+++ b/src/landmark/Route.ts
@@ -4,12 +4,18 @@ import type { CurrencyReward } from '../models/Currency';
 import type { Landmark } from './Landmark';
 import { BattleBackground, LandmarkType } from './Landmark';
 import { type ZoidBlueprint, type CustomizedZoid, getZoidById, buildZoid } from '../models/Zoid';
+import { probabilityRandom } from '../utils/probabilityRandom';
 import { CAMPAIGNS } from '../campaign/campaigns';
+
+export interface RouteEnemy {
+  blueprint: ZoidBlueprint;
+  probability?: number;
+}
 
 export interface Route extends Landmark {
   baseReward: CurrencyReward;
   connects: [string, string];
-  enemies: ZoidBlueprint[];
+  enemies: RouteEnemy[];
   itemDrops?: Drop[];
   routeHealth: number;
   type: typeof LandmarkType.Route;
@@ -20,9 +26,9 @@ export const ROUTES: Route[] = [
     battleBackground: BattleBackground.Grass,
     connects: ['gleam_village', 'abandoned_camp'],
     enemies: [
-      { id: 'merda', level: 5 },
-      { id: 'gator', level: 5 },
-      { id: 'malder', level: 5 },
+      { blueprint: { id: 'merda', level: 5 } },
+      { blueprint: { id: 'gator', level: 5 } },
+      { blueprint: { id: 'malder', level: 5 } },
     ],
     id: 'gleam_outskirts',
     baseReward: { magnis: 30, zi_metal: 4 },
@@ -35,10 +41,10 @@ export const ROUTES: Route[] = [
     battleBackground: BattleBackground.Desert,
     connects: ['abandoned_camp', 'wind_colony'],
     enemies: [
-      { id: 'merda', level: 8 },
-      { id: 'gator', level: 8 },
-      { id: 'malder', level: 8 },
-      { id: 'zatton', level: 10 },
+      { blueprint: { id: 'merda', level: 8 } },
+      { blueprint: { id: 'gator', level: 8 } },
+      { blueprint: { id: 'malder', level: 8 } },
+      { blueprint: { id: 'zatton', level: 10 } },
     ],
     id: 'wind_road',
     baseReward: { magnis: 50, zi_metal: 8 },
@@ -52,11 +58,11 @@ export const ROUTES: Route[] = [
     battleBackground: BattleBackground.Desert,
     connects: ['wind_colony', 'elmia_ruins'],
     enemies: [
-      { id: 'gator', level: 14 },
-      { id: 'malder', level: 12 },
-      { id: 'merda', level: 12 },
-      { id: 'molga', level: 14 },
-      { id: 'zatton', level: 15 },
+      { blueprint: { id: 'gator', level: 14 } },
+      { blueprint: { id: 'malder', level: 12 } },
+      { blueprint: { id: 'merda', level: 12 } },
+      { blueprint: { id: 'molga', level: 14 } },
+      { blueprint: { id: 'zatton', level: 15 } },
     ],
     id: 'elmia_desert',
     name: 'Elmia Desert',
@@ -69,10 +75,10 @@ export const ROUTES: Route[] = [
     battleBackground: BattleBackground.Desert,
     connects: ['wind_colony', 'wind_oasis'],
     enemies: [
-      { id: 'gator', level: 18 },
-      { id: 'malder', level: 16 },
-      { id: 'spiker', level: 18 },
-      { id: 'zatton', level: 20 },
+      { blueprint: { id: 'gator', level: 18 } },
+      { blueprint: { id: 'malder', level: 16 } },
+      { blueprint: { id: 'spiker', level: 18 } },
+      { blueprint: { id: 'zatton', level: 20 } },
     ],
     id: 'dustwind_trail',
     name: 'Dustwind Trail',
@@ -85,10 +91,10 @@ export const ROUTES: Route[] = [
     battleBackground: BattleBackground.Desert,
     connects: ['wind_colony', 'arcobaleno_camp'],
     enemies: [
-      { id: 'gorgodos', level: 22 },
-      { id: 'molga', level: 20 },
-      { id: 'spiker', level: 20 },
-      { id: 'zatton', level: 22 },
+      { blueprint: { id: 'gorgodos', level: 22 } },
+      { blueprint: { id: 'molga', level: 20 } },
+      { blueprint: { id: 'spiker', level: 20 } },
+      { blueprint: { id: 'zatton', level: 22 } },
     ],
     id: 'bandit_trail',
     name: 'Bandit Trail',
@@ -101,11 +107,11 @@ export const ROUTES: Route[] = [
     battleBackground: BattleBackground.Plain,
     connects: ['gleam_village', 'tauros_grotto'],
     enemies: [
-      { id: 'stealth_viper', level: 24 },
-      { id: 'gunbeetle', level: 24 },
-      { id: 'spiker', level: 24 },
-      { id: 'molga', level: 25 },
-      { id: 'malder', level: 24 },
+      { blueprint: { id: 'stealth_viper', level: 24 } },
+      { blueprint: { id: 'gunbeetle', level: 24 } },
+      { blueprint: { id: 'spiker', level: 24 } },
+      { blueprint: { id: 'molga', level: 25 } },
+      { blueprint: { id: 'malder', level: 24 } },
     ],
     devOnly: true,
     id: 'tauros_edge',
@@ -119,10 +125,10 @@ export const ROUTES: Route[] = [
     battleBackground: BattleBackground.Dirt,
     connects: ['tauros_grotto', 'porto_nido'],
     enemies: [
-      { id: 'giraffsworder', level: 26 },
-      { id: 'sea_panther', level: 27 },
-      { id: 'zatton', level: 26 },
-      { id: 'gator', level: 28 },
+      { blueprint: { id: 'giraffsworder', level: 26 } },
+      { blueprint: { id: 'sea_panther', level: 27 }, probability: .01 },
+      { blueprint: { id: 'zatton', level: 26 } },
+      { blueprint: { id: 'gator', level: 28 } },
     ],
     devOnly: true,
     id: 'south_coast',
@@ -138,9 +144,10 @@ export function getRoute(id: string): Route | undefined {
 }
 
 export function randomEnemy(route: Route): CustomizedZoid {
-  const ref = route.enemies[Math.floor(Math.random() * route.enemies.length)];
+  const enemy = probabilityRandom(route.enemies, (e) => e.probability);
+  const ref = enemy.blueprint;
   const stats = buildZoid(ref);
   const baseHp = getZoidById(ref.id).maxHealth;
-  const avgHp = route.enemies.reduce((sum, e) => sum + getZoidById(e.id).maxHealth, 0) / route.enemies.length;
+  const avgHp = route.enemies.reduce((sum, e) => sum + getZoidById(e.blueprint.id).maxHealth, 0) / route.enemies.length;
   return { ...stats, maxHealth: Math.max(1, Math.round(route.routeHealth * (0.6 + baseHp / avgHp / 2 ))) };
 }

--- a/src/landmark/index.ts
+++ b/src/landmark/index.ts
@@ -15,4 +15,4 @@ export {
 export type { Landmark } from './Landmark';
 export { getLandmarkById, getZoidLocations } from './registry';
 export { getRoute, randomEnemy, ROUTES } from './Route';
-export type { Route } from './Route';
+export type { Route, RouteEnemy } from './Route';

--- a/src/landmark/registry.ts
+++ b/src/landmark/registry.ts
@@ -21,7 +21,7 @@ function buildZoidLocationMap(): Map<string, string[]> {
   };
   for (const route of ROUTES) {
     for (const enemy of route.enemies) {
-      add(enemy.id, route.id);
+      add(enemy.blueprint.id, route.id);
     }
   }
   for (const dungeon of DUNGEONS) {

--- a/src/ui/BattleScreen.tsx
+++ b/src/ui/BattleScreen.tsx
@@ -28,7 +28,7 @@ const BattleScreen: Component<BattleScreenProps> = (props) => {
   const routeEnemies = () => {
     if (!isOnRoute()) { return []; }
     const route = currentLandmark() as Route;
-    return [...new Map(route.enemies.map((e) => [e.id, e])).values()];
+    return [...new Map(route.enemies.map((e) => [e.blueprint.id, e.blueprint])).values()];
   };
 
   return (

--- a/src/ui/BattleScreen.tsx
+++ b/src/ui/BattleScreen.tsx
@@ -3,6 +3,7 @@ import { getActiveScanRate } from '../game/Scan';
 import { t } from '../i18n';
 import type { Route } from '../landmark';
 import { getZoidImage } from '../models/Zoid';
+import { resolveProbabilities } from '../utils/probabilityRandom';
 import { enemyZoid, showClickHint } from '../store/gameStore';
 import { battleBackground, currentLandmark, isOnRoute } from '../store/landmarkStore';
 import { getActiveDeviceId, getActiveScanMode } from '../store/scanStore';
@@ -20,6 +21,13 @@ interface BattleScreenProps {
   onClick: () => void;
 }
 
+function formatProbability(value: number): string {
+  const percent = value * 100;
+  if (percent >= 1) { return `${Math.round(percent)}%`; }
+  const decimals = percent >= 0.1 ? 1 : 2;
+  return `${percent.toFixed(decimals)}%`;
+}
+
 const BattleScreen: Component<BattleScreenProps> = (props) => {
   const [showInfo, setShowInfo] = createSignal(false);
 
@@ -28,7 +36,13 @@ const BattleScreen: Component<BattleScreenProps> = (props) => {
   const routeEnemies = () => {
     if (!isOnRoute()) { return []; }
     const route = currentLandmark() as Route;
-    return [...new Map(route.enemies.map((e) => [e.blueprint.id, e.blueprint])).values()];
+    const resolved = resolveProbabilities(route.enemies, (e) => e.probability);
+    const grouped = new Map<string, number>();
+    for (const entry of resolved) {
+      const id = entry.item.blueprint.id;
+      grouped.set(id, (grouped.get(id) ?? 0) + entry.probability);
+    }
+    return [...grouped.entries()].map(([id, probability]) => ({ id, probability }));
   };
 
   return (
@@ -72,7 +86,12 @@ const BattleScreen: Component<BattleScreenProps> = (props) => {
             </div>
             <div class="archive-grid">
               <For each={routeEnemies()}>
-                {(enemy) => <ArchiveCard id={enemy.id} status={getZoidResearch(enemy.id)} />}
+                {(enemy) => (
+                  <div class="route-enemy-wrapper">
+                    <span class="route-enemy-probability">{formatProbability(enemy.probability)}</span>
+                    <ArchiveCard id={enemy.id} status={getZoidResearch(enemy.id)} />
+                  </div>
+                )}
               </For>
             </div>
           </div>

--- a/src/ui/battle.css
+++ b/src/ui/battle.css
@@ -32,6 +32,22 @@
   text-align: center;
 }
 
+.route-enemy-probability {
+  background: rgb(0 0 0 / 60%);
+  border-radius: 4px;
+  color: #e0e0e0;
+  font-size: 0.65rem;
+  padding: 0.1rem 0.3rem;
+  position: absolute;
+  right: 0.2rem;
+  top: 0.2rem;
+  z-index: 1;
+}
+
+.route-enemy-wrapper {
+  position: relative;
+}
+
 .route-label {
   color: #aaa;
   font-size: 0.85rem;

--- a/src/utils/probabilityRandom.ts
+++ b/src/utils/probabilityRandom.ts
@@ -1,5 +1,10 @@
 const MIN_PROBABILITY = 0.01;
 
+export interface ResolvedProbability<T> {
+  item: T;
+  probability: number;
+}
+
 export function probabilityRandom<T>(items: T[], getProbability: (item: T) => number | undefined): T {
   if (items.length === 0) { throw new Error('items must not be empty'); }
   if (items.length === 1) { return items[0]; }
@@ -7,27 +12,27 @@ export function probabilityRandom<T>(items: T[], getProbability: (item: T) => nu
   const resolved = resolveProbabilities(items, getProbability);
   const roll = Math.random();
   let cumulative = 0;
-  for (let i = 0; i < resolved.length; i++) {
-    cumulative += resolved[i];
-    if (roll < cumulative) { return items[i]; }
+  for (const entry of resolved) {
+    cumulative += entry.probability;
+    if (roll < cumulative) { return entry.item; }
   }
   return items[items.length - 1];
 }
 
-function resolveProbabilities<T>(items: T[], getProbability: (item: T) => number | undefined): number[] {
+export function resolveProbabilities<T>(items: T[], getProbability: (item: T) => number | undefined): ResolvedProbability<T>[] {
   const explicit: (number | undefined)[] = items.map(getProbability);
   const withoutCount = explicit.filter((p) => p === undefined).length;
   const explicitSum = explicit.reduce<number>((sum, p) => sum + (p ?? 0), 0);
 
   if (withoutCount === 0) {
     const total = explicitSum || 1;
-    return explicit.map((p) => (p ?? 0) / total);
+    return items.map((item, i) => ({ item, probability: (explicit[i] ?? 0) / total }));
   } else if (explicitSum >= 1) {
     const reserved = withoutCount * MIN_PROBABILITY;
     const scale = (1 - reserved) / explicitSum;
-    return explicit.map((p) => (p !== undefined ? p * scale : MIN_PROBABILITY));
+    return items.map((item, i) => ({ item, probability: explicit[i] !== undefined ? explicit[i] * scale : MIN_PROBABILITY }));
   } else {
     const remainder = (1 - explicitSum) / withoutCount;
-    return explicit.map((p) => p ?? remainder);
+    return items.map((item, i) => ({ item, probability: explicit[i] ?? remainder }));
   }
 }

--- a/src/utils/probabilityRandom.ts
+++ b/src/utils/probabilityRandom.ts
@@ -1,0 +1,33 @@
+const MIN_PROBABILITY = 0.01;
+
+export function probabilityRandom<T>(items: T[], getProbability: (item: T) => number | undefined): T {
+  if (items.length === 0) { throw new Error('items must not be empty'); }
+  if (items.length === 1) { return items[0]; }
+
+  const resolved = resolveProbabilities(items, getProbability);
+  const roll = Math.random();
+  let cumulative = 0;
+  for (let i = 0; i < resolved.length; i++) {
+    cumulative += resolved[i];
+    if (roll < cumulative) { return items[i]; }
+  }
+  return items[items.length - 1];
+}
+
+function resolveProbabilities<T>(items: T[], getProbability: (item: T) => number | undefined): number[] {
+  const explicit: (number | undefined)[] = items.map(getProbability);
+  const withoutCount = explicit.filter((p) => p === undefined).length;
+  const explicitSum = explicit.reduce<number>((sum, p) => sum + (p ?? 0), 0);
+
+  if (withoutCount === 0) {
+    const total = explicitSum || 1;
+    return explicit.map((p) => (p ?? 0) / total);
+  } else if (explicitSum >= 1) {
+    const reserved = withoutCount * MIN_PROBABILITY;
+    const scale = (1 - reserved) / explicitSum;
+    return explicit.map((p) => (p !== undefined ? p * scale : MIN_PROBABILITY));
+  } else {
+    const remainder = (1 - explicitSum) / withoutCount;
+    return explicit.map((p) => p ?? remainder);
+  }
+}

--- a/test/Battle.test.ts
+++ b/test/Battle.test.ts
@@ -12,7 +12,7 @@ import { getZoidResearch, loadZoidResearch } from '../src/store/zoidResearchStor
 const toughRoute: Route = {
   battleBackground: BattleBackground.Grass,
   connects: ['test-a', 'test-b'],
-  enemies: [{ id: 'molga', level: 50 }],
+  enemies: [{ blueprint: { id: 'molga', level: 50 } }],
   id: 'test-route',
   name: 'Test',
   type: LandmarkType.Route,

--- a/test/probabilityRandom.test.ts
+++ b/test/probabilityRandom.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+import { probabilityRandom } from '../src/utils/probabilityRandom';
+
+interface Item { name: string; probability?: number }
+
+function distribution(items: Item[], runs: number): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (let i = 0; i < runs; i++) {
+    const picked = probabilityRandom(items, (it) => it.probability);
+    counts.set(picked.name, (counts.get(picked.name) ?? 0) + 1);
+  }
+  return counts;
+}
+
+describe('probabilityRandom', () => {
+  it('should throw for empty array', () => {
+    expect(() => probabilityRandom([], () => undefined)).toThrow();
+  });
+
+  it('should return the only item for single-element array', () => {
+    const item = { name: 'A' };
+    expect(probabilityRandom([item], () => undefined)).toBe(item);
+  });
+
+  it('should distribute uniformly when no items have probability', () => {
+    const items: Item[] = [{ name: 'A' }, { name: 'B' }, { name: 'C' }, { name: 'D' }];
+    const counts = distribution(items, 10_000);
+    for (const item of items) {
+      const ratio = (counts.get(item.name) ?? 0) / 10_000;
+      expect(ratio).toBeGreaterThan(0.15);
+      expect(ratio).toBeLessThan(0.35);
+    }
+  });
+
+  it('should respect explicit probability and split remainder', () => {
+    const items: Item[] = [
+      { name: 'A', probability: 0.5 },
+      { name: 'B' },
+      { name: 'C' },
+    ];
+    const counts = distribution(items, 10_000);
+    const ratioA = (counts.get('A') ?? 0) / 10_000;
+    const ratioB = (counts.get('B') ?? 0) / 10_000;
+    const ratioC = (counts.get('C') ?? 0) / 10_000;
+    expect(ratioA).toBeGreaterThan(0.4);
+    expect(ratioA).toBeLessThan(0.6);
+    expect(ratioB).toBeGreaterThan(0.15);
+    expect(ratioB).toBeLessThan(0.35);
+    expect(ratioC).toBeGreaterThan(0.15);
+    expect(ratioC).toBeLessThan(0.35);
+  });
+
+  it('should handle all items with explicit probabilities summing to 1', () => {
+    const items: Item[] = [
+      { name: 'A', probability: 0.7 },
+      { name: 'B', probability: 0.3 },
+    ];
+    const counts = distribution(items, 10_000);
+    const ratioA = (counts.get('A') ?? 0) / 10_000;
+    expect(ratioA).toBeGreaterThan(0.6);
+    expect(ratioA).toBeLessThan(0.8);
+  });
+
+  it('should normalize when sum exceeds 1 and give minimum to unset items', () => {
+    const items: Item[] = [
+      { name: 'A', probability: 0.6 },
+      { name: 'B', probability: 0.6 },
+      { name: 'C' },
+    ];
+    const counts = distribution(items, 10_000);
+    const ratioC = (counts.get('C') ?? 0) / 10_000;
+    expect(ratioC).toBeGreaterThan(0);
+    expect(ratioC).toBeLessThan(0.05);
+    const ratioA = (counts.get('A') ?? 0) / 10_000;
+    const ratioB = (counts.get('B') ?? 0) / 10_000;
+    expect(Math.abs(ratioA - ratioB)).toBeLessThan(0.1);
+  });
+
+  it('should normalize when sum equals 1 and give minimum to unset items', () => {
+    const items: Item[] = [
+      { name: 'A', probability: 0.5 },
+      { name: 'B', probability: 0.5 },
+      { name: 'C' },
+      { name: 'D' },
+    ];
+    const counts = distribution(items, 10_000);
+    const ratioC = (counts.get('C') ?? 0) / 10_000;
+    const ratioD = (counts.get('D') ?? 0) / 10_000;
+    expect(ratioC).toBeGreaterThan(0);
+    expect(ratioC).toBeLessThan(0.05);
+    expect(ratioD).toBeGreaterThan(0);
+    expect(ratioD).toBeLessThan(0.05);
+  });
+});

--- a/test/probabilityRandom.test.ts
+++ b/test/probabilityRandom.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { probabilityRandom } from '../src/utils/probabilityRandom';
+import { probabilityRandom, resolveProbabilities } from '../src/utils/probabilityRandom';
 
 interface Item { name: string; probability?: number }
 
@@ -90,5 +90,57 @@ describe('probabilityRandom', () => {
     expect(ratioC).toBeLessThan(0.05);
     expect(ratioD).toBeGreaterThan(0);
     expect(ratioD).toBeLessThan(0.05);
+  });
+});
+
+describe('resolveProbabilities', () => {
+  const getProbability = (item: Item) => item.probability;
+
+  it('should return objects with item and probability', () => {
+    const items: Item[] = [{ name: 'A' }, { name: 'B' }];
+    const result = resolveProbabilities(items, getProbability);
+    expect(result[0].item).toBe(items[0]);
+    expect(result[0]).toHaveProperty('probability');
+    expect(result[1].item).toBe(items[1]);
+  });
+
+  it('should return equal probabilities when none are set', () => {
+    const items: Item[] = [{ name: 'A' }, { name: 'B' }, { name: 'C' }];
+    const result = resolveProbabilities(items, getProbability);
+    expect(result.map((r) => r.probability)).toEqual([1 / 3, 1 / 3, 1 / 3]);
+  });
+
+  it('should split remainder among undefined items', () => {
+    const items: Item[] = [
+      { name: 'A', probability: 0.5 },
+      { name: 'B' },
+      { name: 'C' },
+    ];
+    const result = resolveProbabilities(items, getProbability);
+    expect(result[0].probability).toBeCloseTo(0.5);
+    expect(result[1].probability).toBeCloseTo(0.25);
+    expect(result[2].probability).toBeCloseTo(0.25);
+  });
+
+  it('should normalize when all probabilities are explicit', () => {
+    const items: Item[] = [
+      { name: 'A', probability: 0.6 },
+      { name: 'B', probability: 0.4 },
+    ];
+    const result = resolveProbabilities(items, getProbability);
+    expect(result[0].probability).toBeCloseTo(0.6);
+    expect(result[1].probability).toBeCloseTo(0.4);
+  });
+
+  it('should sum to 1', () => {
+    const items: Item[] = [
+      { name: 'A', probability: 0.01 },
+      { name: 'B' },
+      { name: 'C' },
+      { name: 'D' },
+    ];
+    const result = resolveProbabilities(items, getProbability);
+    const sum = result.reduce((s, r) => s + r.probability, 0);
+    expect(sum).toBeCloseTo(1);
   });
 });


### PR DESCRIPTION
## Summary
- Export `resolveProbabilities` from `probabilityRandom.ts`, returning `ResolvedProbability<T>` objects with item and probability paired together
- Display each enemy's spawn probability as an overlapping badge on the route info panel in `BattleScreen`
- Format percentages intelligently: integers for ≥1%, decimals for smaller values (e.g. 0.1%)
- Add unit tests for `resolveProbabilities`

Closes #148

## Test plan
- [x] Open a route with no explicit probabilities — all enemies show equal percentages
- [x] Open South Coast — `sea_panther` shows ~1%, others share the rest
- [x] Set a very small probability (e.g. 0.001) — displays as "0.1%" not "0%"
- [x] Existing `probabilityRandom` tests still pass