### PR TITLE
Add Maria dialog after defeating Van (#156)

### DIFF
--- a/src/i18n/locales/en/dialog.json
+++ b/src/i18n/locales/en/dialog.json
@@ -102,9 +102,7 @@
     "The desert is east of here. Be careful, the Sleepers out there are stronger than the ones near the village."
   ],
   "maria_van_gone": [
-    "So... Van really left, didn't he? I had a feeling he would. He's just like our father — always putting others before himself.",
-    "I'm sad, of course I am. But I know it's for the best. As long as Zeke is with him, people will keep coming after them. He needs to keep moving.",
-    "Thank you for everything. Knowing that you were there with him... it means a lot. Take care of yourself out there, okay?"
+    "So... Van really left, didn't he? I had a feeling he would. He's just like our father... He needs to keep moving. Thank you for everything. Knowing that you tried... it means a lot. Take care of yourself out there, okay?"
   ],
   "maria_van_fled": [
     "Thanks for your help! Van arrived with Zeke and the Shield Liger and took out those bandits. It was incredible!",

--- a/src/i18n/locales/en/dialog.json
+++ b/src/i18n/locales/en/dialog.json
@@ -101,6 +101,11 @@
     "He's probably out there right now, wandering around the ruins. If you're heading that way, please watch out for him. He's reckless, but he means well.",
     "The desert is east of here. Be careful, the Sleepers out there are stronger than the ones near the village."
   ],
+  "maria_van_gone": [
+    "So... Van really left, didn't he? I had a feeling he would. He's just like our father — always putting others before himself.",
+    "I'm sad, of course I am. But I know it's for the best. As long as Zeke is with him, people will keep coming after them. He needs to keep moving.",
+    "Thank you for everything. Knowing that you were there with him... it means a lot. Take care of yourself out there, okay?"
+  ],
   "maria_van_fled": [
     "Thanks for your help! Van arrived with Zeke and the Shield Liger and took out those bandits. It was incredible!",
     "But Van... he said he's putting everyone in danger by staying here. That he's leaving to protect us.",

--- a/src/i18n/locales/es/dialog.json
+++ b/src/i18n/locales/es/dialog.json
@@ -101,6 +101,9 @@
     "Seguramente está por allá ahora mismo, rondando por las ruinas. Si vas para allá, por favor cuídalo. Es imprudente, pero tiene buen corazón.",
     "El desierto está al este de aquí. Ten cuidado, los Sleepers de allá son más fuertes que los de cerca de la aldea."
   ],
+  "maria_van_gone": [
+    "Así que... Van realmente se fue, ¿verdad? Algo me decía que lo haría. Es igual que nuestro padre... Necesita seguir adelante. Gracias por todo. Saber que lo intentaste... significa mucho. Cuídate mucho, ¿sí?"
+  ],
   "maria_van_fled": [
     "¡Gracias por tu ayuda! Van llegó con Zeke y el Shield Liger y acabaron con esos bandidos. ¡Fue increíble!",
     "Pero Van... dijo que pone a todos en peligro al quedarse aquí. Que se irá para protegernos.",

--- a/src/npc/Npc.test.ts
+++ b/src/npc/Npc.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { CampaignStatus } from '../campaign/Campaign';
+import { CAMPAIGNS } from '../campaign/campaigns';
+import { loadCampaigns } from '../store/campaignStore';
+import { NPCS } from './Npc';
+
+function mariaDialogKey(currentMission: string): string {
+  loadCampaigns(CAMPAIGNS, {
+    sleeper_commander: { currentMission, missionNpcFlags: {}, status: CampaignStatus.Started },
+  });
+  const maria = NPCS.maria_flyheight;
+  const dialog = maria.dialogs.find((d) => !d.unlockRequirement || d.unlockRequirement.isCompleted())
+    ?? maria.dialogs[maria.dialogs.length - 1];
+  return dialog.dialogKey;
+}
+
+describe('Maria Flyheight dialogs', () => {
+  it('shows default dialog before interrogate_bandits', () => {
+    expect(mariaDialogKey('talk_to_maria')).toBe('dialog:maria_flyheight');
+  });
+
+  it('shows fiona dialog after interrogate_bandits', () => {
+    expect(mariaDialogKey('maria_van_status')).toBe('dialog:maria_fiona');
+  });
+
+  it('shows van_fled dialog after talk_to_girl', () => {
+    expect(mariaDialogKey('check_van_colony')).toBe('dialog:maria_van_fled');
+  });
+
+  it('shows van_gone dialog after fight_van', () => {
+    expect(mariaDialogKey('deliver_girl')).toBe('dialog:maria_van_gone');
+  });
+});

--- a/src/npc/Npc.ts
+++ b/src/npc/Npc.ts
@@ -158,6 +158,7 @@ export const NPCS: Record<string, Npc> = {
   },
   maria_flyheight: {
     dialogs: [
+      { dialogKey: 'dialog:maria_van_gone', unlockRequirement: new MissionCompletedRequirement('sleeper_commander', 'fight_van') },
       { dialogKey: 'dialog:maria_van_fled', unlockRequirement: new MissionCompletedRequirement('sleeper_commander', 'talk_to_girl') },
       { dialogKey: 'dialog:maria_fiona', unlockRequirement: new MissionCompletedRequirement('sleeper_commander', 'interrogate_bandits') },
       { dialogKey: 'dialog:maria_flyheight' },


### PR DESCRIPTION
## Summary
- Adds a new `maria_van_gone` dialog that shows after completing the `fight_van` mission, replacing the outdated `maria_van_fled` dialog where Maria keeps asking to bring Van back
- Includes English and Spanish translations
- Adds unit tests for Maria's dialog resolution across campaign states

Closes #156

## Test plan
- [x] Verify Maria shows default dialog before `interrogate_bandits`
- [x] Verify Maria shows `maria_van_fled` after `talk_to_girl`
- [x] Verify Maria shows `maria_van_gone` after `fight_van`
- [x] Run `npx vitest run` — all 430 tests pass