### PR TITLE
Add return-to-city dialog after stray chain (#166)

### DIFF
--- a/src/campaign/campaigns.ts
+++ b/src/campaign/campaigns.ts
@@ -37,6 +37,7 @@ export const CAMPAIGNS: Record<string, Campaign> = {
       { id: 'clear_ruins_demo', goals: [new DungeonCompletionRequirement('sommerso_ruins_sortie', 2)], onComplete: () => grantReward(activateCityActionReward(POST_DEMO_TALK)) },
       { id: 'clear_ruins_stray', goals: [new DungeonCompletionRequirement('sommerso_ruins_sortie', 3)], onComplete: () => grantReward(activateCityActionReward(STRAY_CHAIN_TRIGGER)) },
       { id: 'survive_stray', goals: [new MissionCompletedRequirement('shells_of_time', 'survive_stray')] },
+      { id: 'discuss_in_lab', goals: [new NpcTalkedInCampaignRequirement('shells_of_time', 'dr_thrun')] },
     ],
     unlockRequirements: [new CampaignCompletedRequirement('sleeper_commander')],
   },

--- a/src/i18n/locales/en/campaigns.json
+++ b/src/i18n/locales/en/campaigns.json
@@ -54,6 +54,10 @@
         "name": "Unleashed",
         "description": "Complete another sortie in Sommerso Ruins to witness the effect of Sleeper technology."
       },
+      "discuss_in_lab": {
+        "name": "The Relic",
+        "description": "Return to Porto Nido and discuss what just happened with the doctors."
+      },
       "survive_stray": {
         "name": "Unstoppable",
         "description": "The Stray Helcat won't stay down. Defend yourself!"

--- a/src/i18n/locales/en/dialog.json
+++ b/src/i18n/locales/en/dialog.json
@@ -293,6 +293,14 @@
     "Hah! Alright, alright. You actually fight hard enough to be entertaining. Most idiots fold in five seconds against my Heldigunner.",
     "Look, I hate speeches, so here's the deal. That module? Honestly, I always thought Sleeper tech was worthless garbage. But you're not garbage. The Guylos Empire wants strong pilots. We don't care about your past, your methods, or your ideals. Just whether you can fight."
   ],
+  "dr_thrun_return_to_city": [
+    "...and that's how we escaped from those guys in the desert. Their boss said someone hired them to capture Dad in exchange for Sleeper Modules.",
+    "...I see. You also mentioned finding a small Zoid sealed in a capsule in those ruins. One that fused with a destroyed Zoid and restored it. That is an Organoid. But this statue... it is nothing like one.",
+    "Let me take another look... Hmm. Its structure resembles a Zoid Core, but not like any I have ever seen. It is more like a relic, an ancient Core from a time long before ours.",
+    "Even so, that does not explain the pulse. A dormant Core should not be able to shut down a Zoid's instincts like that. I have visited different time periods and even other worlds, yet I have never seen anything like this.",
+    "If you would allow me, I would like to study this further. During my time in the Republican Army, I knew someone who dedicated her life to studying ancient Zoid species and their Cores. If anyone can help us unravel this mystery, it is her. She lives on Chimera Island.",
+    "I know it is a lot to ask, but could you take us there? We have no transport Zoids, and in times of war the armies have claimed most of them. You will need a Zoid capable of swimming to make the crossing."
+  ],
   "dr_thrun_backstory": [
     "I think you deserve the full truth. My name is Konrad Thrun. I am a Zoid researcher. Years ago, I developed something called the Sleeper Module, designed to give Zoids a form of autonomy.",
     "But research costs money. I approached both the Helic Republic and the Guylos Empire for funding. At first they were interested in the science, but soon it became a race. An autonomous Zoid means fewer pilots at risk and greater firepower. Each side wanted the technology for their own ends.",

--- a/src/i18n/locales/en/ui.json
+++ b/src/i18n/locales/en/ui.json
@@ -87,6 +87,7 @@
   "reset_confirm": "Are you sure? All progress will be lost.",
   "reset_game": "Reset Game",
   "route_enemies": "Route Enemies",
+  "talk_to_doctors": "Talk to the doctors",
   "talk_to_girl": "Talk to the Girl",
   "talk_to_npc": "Talk to {{name}}",
   "total": "Total",

--- a/src/i18n/locales/es/campaigns.json
+++ b/src/i18n/locales/es/campaigns.json
@@ -34,6 +34,10 @@
         "name": "Desatado",
         "description": "Completa otra incursión en las Ruinas Sommerso para presenciar el efecto de la tecnología Sleeper."
       },
+      "discuss_in_lab": {
+        "name": "La Reliquia",
+        "description": "Regresa a Porto Nido y discute lo que acaba de pasar con los doctores."
+      },
       "survive_stray": {
         "name": "Imparable",
         "description": "El Helcat Salvaje no se quedará abajo. ¡Defiéndete!"

--- a/src/i18n/locales/es/dialog.json
+++ b/src/i18n/locales/es/dialog.json
@@ -293,6 +293,14 @@
     "¡Ja! Bueno, bueno. Peleas lo suficientemente fuerte como para entretenerme. La mayoría de los idiotas caen en cinco segundos contra mi Heldigunner.",
     "Mira, odio los discursos, así que voy al grano. ¿Ese módulo? Sinceramente, siempre pensé que la tecnología Sleeper era basura inútil. Pero tú no eres basura. El Imperio de Guylos quiere pilotos fuertes. No nos importa tu pasado, tus métodos ni tus ideales. Solo si sabes pelear."
   ],
+  "dr_thrun_return_to_city": [
+    "...y así fue como escapamos de esos tipos en el desierto. Su jefe, dijo que alguien los contrató para capturar a papá a cambio de Módulos Sleeper.",
+    "...Ya veo. También mencionaste que encontraron un pequeño Zoid sellado en una cápsula en esas mismas ruinas. Uno que se fusionó con un Zoid destruido y lo restauró por completo. Eso es un Organoide. Pero esta estatua... no se parece en nada a uno.",
+    "Déjame echarle otro vistazo... Hmm. Su estructura se parece a un Zoid Core, pero no como ninguno que haya visto. Es más como una reliquia, un Core antiguo de una época mucho antes que la nuestra.",
+    "Aun así, eso no explica el pulso. Un Core inactivo no debería poder desactivar los instintos de un Zoid de esa forma. He visitado distintas épocas e incluso otros mundos, y nunca he visto nada parecido.",
+    "Si me lo permiten, me gustaría estudiar esto más a fondo. Durante mi tiempo en el Ejército Republicano, conocí a alguien que dedicó su vida al estudio de especies antiguas de Zoids y sus Cores. Si alguien puede ayudarnos a descifrar este misterio, es ella. Vive en la Isla Quimera.",
+    "Sé que es mucho pedir, pero ¿podrías llevarnos hasta allá? No contamos con Zoids de transporte, y en tiempos de guerra los ejércitos se han quedado con casi todos. Necesitarás un Zoid capaz de nadar para hacer la travesía."
+  ],
   "dr_thrun_backstory": [
     "Creo que mereces saber toda la verdad. Mi nombre es Konrad Thrun. Soy investigador de Zoids. Hace años desarrollé algo llamado Módulo Sleeper, diseñado para darles a los Zoids una forma de autonomía.",
     "Pero la investigación cuesta dinero. Acudí a la República de Helic y al Imperio de Guylos para obtener financiamiento. Al principio les interesó la ciencia, pero pronto se convirtió en una carrera. Un Zoid autónomo significa menos pilotos en riesgo y mayor potencia de fuego. Cada bando quería la tecnología para sus propios fines.",

--- a/src/i18n/locales/es/ui.json
+++ b/src/i18n/locales/es/ui.json
@@ -87,6 +87,7 @@
   "reset_confirm": "¿Estás seguro? Se perderá todo el progreso.",
   "reset_game": "Reiniciar partida",
   "route_enemies": "Enemigos de Ruta",
+  "talk_to_doctors": "Hablar con los doctores",
   "talk_to_girl": "Hablar con la Niña",
   "talk_to_npc": "Hablar con {{name}}",
   "total": "Total",

--- a/src/landmark/City.ts
+++ b/src/landmark/City.ts
@@ -110,6 +110,7 @@ export const CITIES: City[] = [
       ...AUTOMATIC_ACTIONS.porto_nido_ask_doctor,
       new ActionTalkToNPC('dr_t', [new PilotDefeatRequirement('arcadia_guard')], [new MissionCompletedRequirement(S, 'meet_father')]),
       new ActionTalkToNPC('dr_thrun', [new MissionCompletedRequirement(S, 'meet_father')], [new MissionCompletedRequirement(S, 'clear_ruins_demo')]),
+      new ActionTalkToNPC('dr_thrun', [new MissionCompletedRequirement(S, 'survive_stray')], undefined, undefined, 'ui:talk_to_doctors'),
     ],
     battleBackground: BattleBackground.Dirt,
     devOnly: true,

--- a/src/landmark/portoNido.test.ts
+++ b/src/landmark/portoNido.test.ts
@@ -104,14 +104,14 @@ describe('shells_of_time campaign', () => {
   it('has 3 missions', () => {
     const campaign = CAMPAIGNS['shells_of_time'];
     expect(campaign).toBeDefined();
-    expect(campaign.missions.length).toBe(9);
+    expect(campaign.missions.length).toBe(10);
   });
 
   it('missions are in correct order', () => {
     const ids = CAMPAIGNS['shells_of_time'].missions.map((m) => m.id);
     expect(ids).toEqual([
       'head_to_porto_nido', 'fight_arcadia_guard', 'meet_dr_t', 'clear_ruins', 'meet_father',
-      'father_backstory', 'clear_ruins_demo', 'clear_ruins_stray', 'survive_stray',
+      'father_backstory', 'clear_ruins_demo', 'clear_ruins_stray', 'survive_stray', 'discuss_in_lab',
     ]);
   });
 

--- a/src/npc/Npc.ts
+++ b/src/npc/Npc.ts
@@ -63,6 +63,17 @@ export const NPCS: Record<string, Npc> = {
   dr_thrun: {
     dialogs: [
       {
+        dialogKey: 'dialog:dr_thrun_return_to_city',
+        speakers: {
+          0: { speakerKey: 'pilots:kara', portrait: 'images/pilots/girl.png' },
+          1: { speakerKey: 'pilots:dr_t', portrait: 'images/pilots/dr_t.png' },
+          2: { speakerKey: '' },
+          3: { speakerKey: 'pilots:dr_t', portrait: 'images/pilots/dr_t.png' },
+          4: { speakerKey: '' },
+        },
+        unlockRequirement: new MissionCompletedRequirement('shells_of_time', 'survive_stray'),
+      },
+      {
         dialogKey: 'dialog:dr_thrun_stray_intro',
         unlockRequirement: new MissionCompletedRequirement('shells_of_time', 'clear_ruins_demo'),
       },


### PR DESCRIPTION
## Summary
- Adds a new dialog scene in Porto Nido after the stray Helcat chain where Kara, Dr. T, and Dr. Thrun discuss the ancient statue
- Introduces the concept of Organoids vs ancient Zoid Cores and sets up the journey to Chimera Island
- Adds `discuss_in_lab` mission step to the `shells_of_time` campaign
- Full i18n support (EN/ES) for dialog, campaign mission, and UI label

## Test plan
- [x] All 441 tests pass
- [x] Lint and TypeScript checks pass
- [x] After completing the stray chain, Porto Nido shows "Talk to the doctors" action
- [x] Dialog plays with correct speaker portraits (Kara → Dr. T → Dr. Thrun → Dr. T → Dr. Thrun)
- [x] Mission `discuss_in_lab` advances after the conversation

Closes #166