### PR TITLE
Add terrain indicator and refactor ArchiveCard (#173)

### DIFF
--- a/src/models/Terrain.test.ts
+++ b/src/models/Terrain.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { getTerrainBonus, TerrainType } from './Terrain';
+import { getTerrainBorderStyle, getTerrainBonus, TERRAIN_COLORS, TerrainType } from './Terrain';
 
 describe('getTerrainBonus', () => {
   it('returns 1.0 for matching single terrain type', () => {
@@ -30,5 +30,26 @@ describe('getTerrainBonus', () => {
     expect(getTerrainBonus(TerrainType.Water, [TerrainType.Air])).toBe(0.25);
     expect(getTerrainBonus(TerrainType.Air, [TerrainType.Water])).toBe(0.10);
     expect(getTerrainBonus(TerrainType.Land, [TerrainType.Water])).toBe(0.25);
+  });
+});
+
+describe('getTerrainBorderStyle', () => {
+  it('returns solid color for single terrain', () => {
+    expect(getTerrainBorderStyle([TerrainType.Land])).toBe(TERRAIN_COLORS[TerrainType.Land]);
+    expect(getTerrainBorderStyle([TerrainType.Water])).toBe(TERRAIN_COLORS[TerrainType.Water]);
+    expect(getTerrainBorderStyle([TerrainType.Air])).toBe(TERRAIN_COLORS[TerrainType.Air]);
+  });
+
+  it('returns gradient for multiple terrains', () => {
+    const result = getTerrainBorderStyle([TerrainType.Water, TerrainType.Land]);
+    expect(result).toContain('linear-gradient');
+    expect(result).toContain(TERRAIN_COLORS[TerrainType.Land]);
+    expect(result).toContain(TERRAIN_COLORS[TerrainType.Water]);
+  });
+
+  it('sorts terrain colors alphabetically for consistency', () => {
+    const a = getTerrainBorderStyle([TerrainType.Water, TerrainType.Air]);
+    const b = getTerrainBorderStyle([TerrainType.Air, TerrainType.Water]);
+    expect(a).toBe(b);
   });
 });

--- a/src/models/Terrain.ts
+++ b/src/models/Terrain.ts
@@ -6,11 +6,28 @@ export const TerrainType = {
 
 export type TerrainType = (typeof TerrainType)[keyof typeof TerrainType];
 
+export const TERRAIN_COLORS: Record<TerrainType, string> = {
+  [TerrainType.Air]: '#c8e6ff',
+  [TerrainType.Land]: '#8b6914',
+  [TerrainType.Water]: '#2196f3',
+};
+
 export const TERRAIN_BONUS_TABLE: Record<TerrainType, Record<TerrainType, number>> = {
   [TerrainType.Air]: { [TerrainType.Air]: 1.00, [TerrainType.Land]: 0.10, [TerrainType.Water]: 0.10 },
   [TerrainType.Land]: { [TerrainType.Air]: 0.25, [TerrainType.Land]: 1.00, [TerrainType.Water]: 0.25 },
   [TerrainType.Water]: { [TerrainType.Air]: 0.25, [TerrainType.Land]: 0.00, [TerrainType.Water]: 1.00 },
 };
+
+export function getTerrainBorderStyle(terrainTypes: TerrainType[]): string {
+  const sorted = [...terrainTypes].sort();
+  const colors = sorted.map((t) => TERRAIN_COLORS[t]);
+  if (colors.length === 1) {
+    return colors[0];
+  }
+  const step = 100 / colors.length;
+  const stops = colors.flatMap((c, i) => [`${c} ${step * i}%`, `${c} ${step * (i + 1)}%`]);
+  return `linear-gradient(to right, ${stops.join(', ')})`;
+}
 
 export function getTerrainBonus(routeTerrain: TerrainType, zoidTerrainTypes: TerrainType[]): number {
   return Math.max(...zoidTerrainTypes.map((t) => TERRAIN_BONUS_TABLE[routeTerrain][t]));

--- a/src/ui/LabPanel.tsx
+++ b/src/ui/LabPanel.tsx
@@ -1,13 +1,13 @@
 import { type Component, createMemo, For, Show } from 'solid-js';
 import { t } from '../i18n';
-import { FACTIONS } from '../models/Faction';
 import { Currency } from '../models/Currency';
-import { getZoidImage, ZOID_LIST } from '../models/Zoid';
+import { ZOID_LIST, ZoidResearchStatus } from '../models/Zoid';
 import { isMissionCompleted } from '../store/campaignStore';
 import { playerStats } from '../store/gameStore';
 import { party } from '../store/partyStore';
 import { getZoidDataCount } from '../store/zoidDataStore';
 import { getCurrency } from '../store/walletStore';
+import { ArchiveCard } from './ZiArchivePanel';
 import './lab.css';
 
 interface LabPanelProps {
@@ -49,18 +49,14 @@ const LabPanel: Component<LabPanelProps> = (props) => {
                 const canAfford = () => isFirstFree() || getCurrency(Currency.Magnis) >= entry.data.price;
                 const isDisabled = () => isDeployed() || !canAfford();
                 return (
-                  <button
-                    class={`archive-card lab-card ${isDisabled() ? 'lab-card--disabled' : ''}`}
+                  <ArchiveCard
+                    class="lab-card"
                     disabled={isDisabled()}
-                    style={{ 'background-color': `${FACTIONS[entry.data.faction].color}33`, 'border-color': FACTIONS[entry.data.faction].color }}
+                    id={entry.id}
                     onClick={() => props.onBuy(entry.id)}
+                    showTooltip={false}
+                    status={ZoidResearchStatus.Created}
                   >
-                    <img
-                      class="archive-card-image"
-                      src={getZoidImage(entry.id)}
-                      alt={entry.data.name}
-                    />
-                    <span class="archive-card-name">{entry.data.name}</span>
                     <Show when={isDeployed()}>
                       <div class="lab-card-price">
                         <span>{t('ui:deployed')}</span>
@@ -79,7 +75,7 @@ const LabPanel: Component<LabPanelProps> = (props) => {
                       </Show>
                     </Show>
                     <span class="lab-card-zdata">Z-Data: {getZoidDataCount(entry.id)}</span>
-                  </button>
+                  </ArchiveCard>
                 );
               }}
             </For>

--- a/src/ui/ZiArchivePanel.tsx
+++ b/src/ui/ZiArchivePanel.tsx
@@ -1,4 +1,4 @@
-import { type Component, createMemo, For, Show } from 'solid-js';
+import { type Component, createMemo, For, type ParentComponent, Show } from 'solid-js';
 import { t } from '../i18n';
 import { getZoidLocations } from '../landmark';
 import { FACTIONS } from '../models/Faction';
@@ -7,6 +7,7 @@ import {
   ZOID_LIST,
   ZoidResearchStatus,
 } from '../models/Zoid';
+import { getTerrainBorderStyle } from '../models/Terrain';
 import { getZoidDataCount } from '../store/zoidDataStore';
 import { getZoidResearch } from '../store/zoidResearchStore';
 import './archive.css';
@@ -50,45 +51,63 @@ const ZiArchivePanel: Component<ZiArchivePanelProps> = (props) => {
   );
 };
 
-export const ArchiveCard: Component<{ id: string; status: ZoidResearchStatus | null }> = (props) => {
+interface ArchiveCardProps {
+  class?: string;
+  disabled?: boolean;
+  id: string;
+  onClick?: () => void;
+  showTooltip?: boolean;
+  status: ZoidResearchStatus | null;
+}
+
+export const ArchiveCard: ParentComponent<ArchiveCardProps> = (props) => {
   const zoid = () => ZOID_LIST[props.id];
   const locations = () => getZoidLocations(props.id);
   const statusClass = () => props.status ? `archive-card--${props.status}` : 'archive-card--seen';
+  const showTooltip = () => props.showTooltip ?? true;
 
   return (
-    <div
-      class={`archive-card ${statusClass()}`}
+    <button
+      class={`archive-card ${statusClass()} ${props.class ?? ''}`}
+      disabled={props.disabled}
       style={{ 'background-color': `${FACTIONS[zoid().faction].color}33`, 'border-color': FACTIONS[zoid().faction].color }}
+      onClick={() => props.onClick?.()}
     >
-      <img
-        class="archive-card-image"
-        src={getZoidImage(props.id)}
-        alt={zoid().name}
-      />
-      <span class="archive-card-name">{props.status ? zoid().name : '???'}</span>
-      <div class="archive-card-tooltip">
-        <Show when={props.status}>
-          <span class="archive-card-tooltip-name">{t(`ui:archive_status_${props.status}`)}</span>
-          <Show when={props.status === ZoidResearchStatus.Scanned}>
-            <span class="archive-card-tooltip-desc">
-              {t('ui:archive_scans', { count: getZoidDataCount(props.id) })}
-            </span>
-          </Show>
-          <Show when={props.status === ZoidResearchStatus.Created}>
-            <span class="archive-card-tooltip-desc">{t('ui:archive_attack', { value: zoid().attack })}</span>
-            <span class="archive-card-tooltip-desc">{t('ui:archive_hp', { value: zoid().maxHealth })}</span>
-          </Show>
-        </Show>
-        <span class="archive-card-tooltip-name">{t('ui:locations')}</span>
-        <Show when={locations().length > 0} fallback={<span class="archive-card-tooltip-desc">???</span>}>
-          <div class="archive-card-locations">
-            <For each={locations()}>
-              {(locId) => <span class="archive-card-location">• {t(`locations:${locId}`)}</span>}
-            </For>
-          </div>
-        </Show>
+      <div class="archive-card-inner">
+        <div class="archive-card-terrain" style={{ background: getTerrainBorderStyle(zoid().terrainTypes) }} />
+        <img
+          class="archive-card-image"
+          src={getZoidImage(props.id)}
+          alt={zoid().name}
+        />
+        <span class="archive-card-name">{props.status ? zoid().name : '???'}</span>
+        {props.children}
       </div>
-    </div>
+      <Show when={showTooltip()}>
+        <div class="archive-card-tooltip">
+          <Show when={props.status}>
+            <span class="archive-card-tooltip-name">{t(`ui:archive_status_${props.status}`)}</span>
+            <Show when={props.status === ZoidResearchStatus.Scanned}>
+              <span class="archive-card-tooltip-desc">
+                {t('ui:archive_scans', { count: getZoidDataCount(props.id) })}
+              </span>
+            </Show>
+            <Show when={props.status === ZoidResearchStatus.Created}>
+              <span class="archive-card-tooltip-desc">{t('ui:archive_attack', { value: zoid().attack })}</span>
+              <span class="archive-card-tooltip-desc">{t('ui:archive_hp', { value: zoid().maxHealth })}</span>
+            </Show>
+          </Show>
+          <span class="archive-card-tooltip-name">{t('ui:locations')}</span>
+          <Show when={locations().length > 0} fallback={<span class="archive-card-tooltip-desc">???</span>}>
+            <div class="archive-card-locations">
+              <For each={locations()}>
+                {(locId) => <span class="archive-card-location">• {t(`locations:${locId}`)}</span>}
+              </For>
+            </div>
+          </Show>
+        </div>
+      </Show>
+    </button>
   );
 };
 

--- a/src/ui/archive.css
+++ b/src/ui/archive.css
@@ -90,15 +90,42 @@
 }
 
 .archive-card {
-  align-items: center;
+  background: none;
   border: 1px solid var(--theme-border);
   border-radius: 8px;
+  color: inherit;
+  cursor: pointer;
   display: flex;
   flex-direction: column;
-  gap: 0.3rem;
+  font: inherit;
   overflow: visible;
+  position: relative;
+  text-align: left;
+}
+
+.archive-card:disabled {
+  cursor: not-allowed;
+  opacity: 0.4;
+}
+
+.archive-card-inner {
+  align-items: center;
+  border-radius: 7px;
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 0.3rem;
+  overflow: hidden;
   padding: 0.5rem;
   position: relative;
+}
+
+.archive-card-terrain {
+  bottom: 0;
+  height: 4px;
+  left: 0;
+  position: absolute;
+  right: 0;
 }
 
 .archive-card-image {

--- a/src/ui/lab.css
+++ b/src/ui/lab.css
@@ -11,22 +11,12 @@
 }
 
 .lab-card {
-  background: none;
-  border: 1px solid var(--theme-border);
-  color: inherit;
-  cursor: pointer;
-  font: inherit;
   transition: transform 0.1s, box-shadow 0.1s;
 }
 
 .lab-card:hover:not(:disabled) {
   box-shadow: 0 0 8px rgb(255 255 255 / 20%);
   transform: scale(1.05);
-}
-
-.lab-card--disabled {
-  cursor: not-allowed;
-  opacity: 0.4;
 }
 
 .lab-card-price {


### PR DESCRIPTION
## Summary
- Add colored terrain stripe at the bottom of Zoid cards (land=brown, water=blue, air=light blue) with sectioned gradient for multi-terrain Zoids
- Add `TERRAIN_COLORS` and `getTerrainBorderStyle()` to `Terrain.ts`
- Refactor `ArchiveCard` into a reusable `ParentComponent` with `children`, `class`, `disabled`, `onClick`, `showTooltip` props
- LabPanel now reuses `ArchiveCard` instead of duplicating card markup
- Add unit tests for `getTerrainBorderStyle`

## Test plan
- [x] All 444 tests pass
- [x] Verify terrain stripe in Zi-Archive catalog (land, water, air, multi-terrain)
- [x] Verify Lab panel renders correctly with reusable ArchiveCard
- [x] Verify tooltip works in archive but hidden in lab
- [x] Verify route enemy info cards still work