### PR TITLE
Improve route info panel and scrollbar styling

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -17,6 +17,25 @@
   box-sizing: border-box;
   margin: 0;
   padding: 0;
+  scrollbar-color: var(--theme-border) transparent;
+  scrollbar-width: thin;
+}
+
+*::-webkit-scrollbar {
+  width: 6px;
+}
+
+*::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+*::-webkit-scrollbar-thumb {
+  background: var(--theme-border);
+  border-radius: 3px;
+}
+
+*::-webkit-scrollbar-thumb:hover {
+  background: var(--theme-button-hover);
 }
 
 body {

--- a/src/ui/BattleScreen.tsx
+++ b/src/ui/BattleScreen.tsx
@@ -88,10 +88,9 @@ const BattleScreen: Component<BattleScreenProps> = (props) => {
             <div class="archive-grid">
               <For each={routeEnemies()}>
                 {(enemy) => (
-                  <div class="route-enemy-wrapper">
+                  <ArchiveCard id={enemy.id} status={getZoidResearch(enemy.id)}>
                     <span class="route-enemy-probability">{formatProbability(enemy.probability)}</span>
-                    <ArchiveCard id={enemy.id} status={getZoidResearch(enemy.id)} />
-                  </div>
+                  </ArchiveCard>
                 )}
               </For>
             </div>

--- a/src/ui/archive.css
+++ b/src/ui/archive.css
@@ -37,7 +37,9 @@
   background: var(--theme-deep-bg);
   border: 2px solid var(--theme-border);
   border-radius: 12px;
+  max-height: 80vh;
   max-width: 600px;
+  overflow-y: auto;
   padding: 1rem;
   width: 90%;
 }

--- a/src/ui/battle.css
+++ b/src/ui/battle.css
@@ -39,13 +39,9 @@
   font-size: 0.65rem;
   padding: 0.1rem 0.3rem;
   position: absolute;
-  right: 0.2rem;
-  top: 0.2rem;
+  right: 0.3rem;
+  top: 0.3rem;
   z-index: 1;
-}
-
-.route-enemy-wrapper {
-  position: relative;
 }
 
 .route-label {


### PR DESCRIPTION
## Summary
- Move route enemy probability badge inside ArchiveCard so it renders within the card boundaries
- Add max-height and scroll to archive panel to prevent it from overflowing the viewport
- Add themed scrollbar styling globally (thin, dark, matching the UI theme)

## Test plan
- [x] Open route info panel and verify percentages appear inside each card
- [x] Open route info panel with many enemies and verify scroll works
- [x] Check scrollbar styling across panels that overflow