### PR TITLE
Release 0.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zoids-sleeper",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zoids-sleeper",
-      "version": "0.5.2",
+      "version": "0.6.0",
       "dependencies": {
         "i18next": "^26.0.3",
         "solid-js": "^1.9.11"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zoids-sleeper",
   "private": true,
-  "version": "0.5.2",
+  "version": "0.6.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/game/migrations.ts
+++ b/src/game/migrations.ts
@@ -8,6 +8,7 @@ export type MigrationData = Partial<SaveData> & Record<string, unknown>;
 type MigrationFn = (data: MigrationData) => void;
 
 const migrations: Record<string, MigrationFn> = {
+  '0.6.0': () => {},
   '0.5.2': () => {},
   '0.5.1': (data) => {
     const now = Date.now();


### PR DESCRIPTION
## v0.6.0 — Release Overview

Covers all changes since v0.1.0: 40 PRs, 366 files changed, ~10,000 net lines added.

### Content growth

| | v0.1.0 | v0.6.0 |
|---|---|---|
| Zoid species | 18 | 64 |
| Pilots | 17 | 35 |
| Locations | 7 | 14 |
| Campaign missions | 38 | 89 |
| Source files (TS/TSX) | 140 | 244 |
| Test files | 39 | 76 (593 tests) |
| i18n entries (en) | 590 | 1,728 |

---

### New systems

**Evolution** (`src/evolution/`) — Rule-based evolution system. Evolutions trigger automatically on level-up when conditions are met, or manually via upgrade items. Rule types: `LevelRule`, `AttackRule`, `HealthRule`, `FactionRule`, `ItemRule`. Rules can be combined with `AllOfRule` (AND) and `AtLeastOneOfRule` (OR). The UI shows evolution hints per zoid and the supplies panel lets players apply item-based evolutions.

**Factions** (`src/models/Faction`) — 6 factions: Dark Army, Guylos Empire, Helic Republic, Neutral, Neo Zenebas, Zenebas Empire. The player's faction determines an attack multiplier when using zoids from different factions (0.85x to 1.30x, same-faction bonus). Faction-locked routes gate access based on the player's choice. Faction is set through story decisions (e.g., joining the Republic or Guylos during campaign).

**Terrain** (`src/models/Terrain`) — 3 terrain types: Air, Land, Water. Each zoid species declares compatible terrains. In combat, a zoid's attack is multiplied by a terrain bonus: 1.0x on matching terrain, 0.10x–0.25x on mismatches (Water zoids deal 0x on Land). The UI shows terrain icons on zoid cards and colored borders in the archive.

**Transport zoids** (`src/models/TransportZoid`) — Gustav and Gustav MC can be assigned as the party's transport. They boost the nurturing tank: Gustav gives 1.25x fragment gain, Gustav MC gives 1.5x reborn bonus. Selected via a picker modal in the nurturing panel.

**Cores & Nurturing** (`src/item/ZoidCore`, `src/store/nurturingStore`) — Zoid Cores (MiniCore, ProtoCore) are items placed in a nurturing tank with up to 4 slots. Cores accumulate fragments over time; when full, a new zoid species emerges from a pool specific to the core type. The tank also supports reborn zoids (level 100+), which restart at level 0 with +25% attack per reborn cycle. Core visuals are composed from faction color, pattern, and shape layers.

**Organoids** (`src/models/Organoid`) — Enemy enhancement that activates at 25% enemy health on the last enemy of a battle. Multiplies enemy attack and max health (Zeke: 2x, Shadow: 10x), plays a 2-second animation, and fully heals the enemy. A comeback mechanic for boss fights.

**Wild dungeon bosses** (`src/game/WildBossBattle`) — Dungeons can now have multi-wave wild zoid bosses (not just pilot battles). Each defeated enemy awards core fragments for the nurturing tank.

**Configurable dungeon events** (`src/dungeon/DungeonEventOutcome`) — Dungeon events present choices with weighted random outcomes: damage, healing, attack buffs, item rewards, currency, ambushes (wild or pilot). Each outcome has a weight for probability (e.g., 50% buff + 50% wild ambush + 0.5% rare item).

**Decisions** (`src/dialog/DecisionScreen`) — Player-facing choice screens during story dialogs. Each choice has a callback that can set faction, start campaigns, or trigger story events. Currently used for the Republic/Guylos faction decision points.

**Feature flags** (`src/featureFlag/`) — Replaces the old `devOnly` boolean. `DevFeatureFlag` for dev-only features, `VersionFeatureFlag` for features enabled from a specific game version. Used by requirements and UI gating.

**Zoid catalog** (`src/models/zoidCatalog`) — Centralized species registry with full data: type, terrain, size, weight, speed, dimensions, evolution chains. Extracted from the old inline definitions in `Zoid.ts`.

**Zoid detail modal** (`src/ui/ZoidDetailModal`) — Full species view with stats, terrain icons, description, evolution hints, and stat sorting.

---

### New requirement types (11)

CampaignStarted, CoreNurtured, DungeonCompletion, Faction, FeatureFlag, Impossible, OwnZoidForTerrain, SpeciesDefeat, SpeciesZiData, WildDefeat, ZoidAtLevel, ZoidCreated

### New reward types (8)

ActivateCityAction, Composite, RemoveItem, RemoveZiData, RemoveZoid, TypedZoidCore, ZoidCore, Zoid

---

### Campaign progress

The Sleeper Commander campaign advances from Wind Colony to Desert Gorge (Act 12):

- Porto Nido city (lab, shop, locked reinforcements)
- Sommerso Ruins dungeon + Dr. Thrun encounter
- Sleeper backstory, Helcat demos, stray zoid chain
- Chimera Island: Republican Intervention → Unia's Trials → sanctuary secrets → Core Shop
- Antagonist pilots: Raven, Opis Kerone, Gale Task
- Forced duels, organoid mechanics, Ancient Tortoise fight, Beacon emergence
- Porto Nido kidnapping → Desert Gorge confrontation chain

Two new campaign segments: **Helic Republic** and **Guylos Empire**.

---

### New content

- **46 zoid species** — full list in `src/models/zoidCatalog.ts`
- **18 pilots** — Raven, Gale Task, Opis, Unia, Beacon, Dr. Thrun, and 12 others
- **7 locations** — Porto Nido, Sommerso Ruins, Chimera Island, Desert Gorge, Tauros Grotto, Imperial Camp, Republican Camp
- **4 animated cutscenes** — Ancient Tortoise beat, cocoon shoot, tortoise evolution (start/end)

---

### UI changes

- Enemy spawn probabilities on route info panel
- Terrain indicator on routes
- Stat sort bar for party and archive panels
- Improved supplies panel with evolution support
- Redesigned ArchiveCard with terrain border colors
- Better scrollbar styling

### Bug fixes

- Fixed first Van fight not triggering correctly
- Scan UI fix and newOnly filter state persistence
- Unlock requirements for route enemies
- Currency rewards visible in dungeon battles

### Migrations

Save data migrations for versions 0.2.0 through 0.6.0 (13 entries). Notable: party data restructured (0.4.1), faction backfill (0.4.3), nurturing slot migration (0.4.7), reborn count derivation (0.4.9), evolving flag backfill (0.5.0).