### PR TITLE
Patch 0.6.1

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,8 @@
 name: Deploy to GitHub Pages
 
 on:
-  push:
-    branches: [master]
+  release:
+    types: [published]
   workflow_dispatch:
 
 permissions:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zoids-sleeper",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zoids-sleeper",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "dependencies": {
         "i18next": "^26.0.3",
         "solid-js": "^1.9.11"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zoids-sleeper",
   "private": true,
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/game/migrations.ts
+++ b/src/game/migrations.ts
@@ -8,6 +8,25 @@ export type MigrationData = Partial<SaveData> & Record<string, unknown>;
 type MigrationFn = (data: MigrationData) => void;
 
 const migrations: Record<string, MigrationFn> = {
+  '0.6.1': (data) => {
+    const campaign = data.campaigns?.['sleeper_commander'];
+    if (!campaign) {return;}
+
+    if (campaign.status === 'completed') {
+      data.campaigns!['sleeper_commander'] = {
+        currentMission: 'deliver_girl',
+        missionNpcFlags: {},
+        status: 'started',
+      };
+      return;
+    }
+
+    const flags = campaign.missionNpcFlags;
+    if (flags?.['sleeper_commander:girl'] !== undefined) {
+      flags['sleeper_commander:kara'] = flags['sleeper_commander:girl'];
+      delete flags['sleeper_commander:girl'];
+    }
+  },
   '0.6.0': () => {},
   '0.5.2': () => {},
   '0.5.1': (data) => {


### PR DESCRIPTION
## Summary
- Add 0.6.1 migration: replays the 0.4.2 migration (rename girl→kara NPC flag, reset completed sleeper_commander campaign to deliver_girl mission) for saves upgrading from v0.1.0
- Change deploy workflow to trigger on release publish instead of push to master
- Bump version to 0.6.1