### PR TITLE
Fix migration resetting completed sleeper_commander

### DIFF
--- a/src/game/migrations.test.ts
+++ b/src/game/migrations.test.ts
@@ -48,8 +48,75 @@ describe('migration 0.4.5', () => {
   });
 });
 
+describe('migration 0.6.1', () => {
+  it('resets completed campaign to deliver_girl when shells_of_time not started', () => {
+    const data = baseSave({
+      campaigns: {
+        sleeper_commander: {
+          currentMission: '',
+          missionNpcFlags: {},
+          status: 'completed',
+        },
+      } as unknown as MigrationData['campaigns'],
+      version: '0.6.0',
+    });
+
+    migrate(data, '0.6.0');
+
+    expect(data.campaigns!['sleeper_commander']).toEqual({
+      currentMission: { goalState: [], id: 'deliver_girl' },
+      missionNpcFlags: {},
+      status: 'started',
+    });
+  });
+
+  it('preserves completed status when shells_of_time is started', () => {
+    const data = baseSave({
+      campaigns: {
+        sleeper_commander: {
+          currentMission: '',
+          missionNpcFlags: {},
+          status: 'completed',
+        },
+        shells_of_time: {
+          currentMission: 'head_to_porto_nido',
+          missionNpcFlags: {},
+          status: 'started',
+        },
+      } as unknown as MigrationData['campaigns'],
+      version: '0.6.0',
+    });
+
+    migrate(data, '0.6.0');
+
+    expect(data.campaigns!['sleeper_commander'].status).toBe('completed');
+  });
+
+  it('preserves completed status when shells_of_time is completed', () => {
+    const data = baseSave({
+      campaigns: {
+        sleeper_commander: {
+          currentMission: '',
+          missionNpcFlags: {},
+          status: 'completed',
+        },
+        shells_of_time: {
+          currentMission: '',
+          missionNpcFlags: {},
+          status: 'completed',
+        },
+      } as unknown as MigrationData['campaigns'],
+      version: '0.6.0',
+    });
+
+    migrate(data, '0.6.0');
+
+    expect(data.campaigns!['sleeper_commander'].status).toBe('completed');
+  });
+});
+
 describe('migration 0.4.2', () => {
-  it('resets completed campaign to deliver_girl', () => {
+  it('resets completed campaign to deliver_girl when shells_of_time not started', () => {
     const data = baseSave({
       campaigns: {
         sleeper_commander: {
@@ -67,6 +134,27 @@ describe('migration 0.4.2', () => {
       missionNpcFlags: {},
       status: 'started',
     });
+  });
+
+  it('preserves completed status when shells_of_time is started', () => {
+    const data = baseSave({
+      campaigns: {
+        sleeper_commander: {
+          currentMission: '',
+          missionNpcFlags: {},
+          status: 'completed',
+        },
+        shells_of_time: {
+          currentMission: 'head_to_porto_nido',
+          missionNpcFlags: {},
+          status: 'started',
+        },
+      } as unknown as MigrationData['campaigns'],
+    });
+
+    migrate(data, '0.4.1');
+
+    expect(data.campaigns!['sleeper_commander'].status).toBe('completed');
   });
 
   it('does not affect players before fight_van', () => {

--- a/src/game/migrations.ts
+++ b/src/game/migrations.ts
@@ -22,6 +22,12 @@ const migrations: Record<string, MigrationFn> = {
     const campaign = campaigns?.['sleeper_commander'];
     if (!campaign) {return;}
 
+    const shellsStatus = campaigns?.['shells_of_time']?.status;
+    if (shellsStatus === 'started' || shellsStatus === 'completed') {
+      campaigns!['sleeper_commander'] = { currentMission: '', status: 'completed' };
+      return;
+    }
+
     if (campaign.status === 'completed') {
       campaigns!['sleeper_commander'] = {
         currentMission: 'deliver_girl',
@@ -106,6 +112,12 @@ const migrations: Record<string, MigrationFn> = {
     const campaigns = data.campaigns as Record<string, Record<string, unknown>> | undefined;
     const campaign = campaigns?.['sleeper_commander'];
     if (!campaign) {return;}
+
+    const shellsStatus = campaigns?.['shells_of_time']?.status;
+    if (shellsStatus === 'started' || shellsStatus === 'completed') {
+      campaigns!['sleeper_commander'] = { currentMission: '', status: 'completed' };
+      return;
+    }
 
     if (campaign.status === 'completed') {
       campaigns!['sleeper_commander'] = {


### PR DESCRIPTION
## Summary
- Migrations 0.4.2 and 0.6.1 incorrectly reset `sleeper_commander` from `completed` to `started` even when the player had already progressed to `shells_of_time`
- Added a guard in both migrations: if `shells_of_time` is `started` or `completed`, force `sleeper_commander` to `completed` and skip the reset
- Added unit tests for both migrations covering the guard logic

## Test plan
- [x] Unit tests pass (`src/game/migrations.test.ts` — 12 tests)
- [x] Integration tests pass (`test/migrations.test.ts` — 25 tests)
- [x] Import the save file `after-gale-duel.txt` in version 0.6.1 and verify `sleeper_commander` stays `completed`