### PR TITLE
Fix missions not advancing after buying items in shop

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -151,7 +151,10 @@ const App: Component = () => {
       <Show when={activeShop()}>
         <ShopPanel
           shop={activeShop()!}
-          onBuy={(item, amount) => buyItem(item.id, amount)}
+          onBuy={(item, amount) => {
+            buyItem(item.id, amount);
+            checkCampaigns();
+          }}
           onClose={() => setActiveShop(null)}
         />
       </Show>

--- a/src/store/campaignStore.test.ts
+++ b/src/store/campaignStore.test.ts
@@ -4,8 +4,10 @@ import { CampaignStatus, Mission, type Campaign } from '../campaign/Campaign';
 import { AllOfRequirement } from '../requirement/AllOfRequirement';
 import { CampaignCompletedRequirement } from '../requirement/CampaignCompletedRequirement';
 import { DungeonCompletionRequirement, type DungeonRequirementSaveData } from '../requirement/DungeonCompletionRequirement';
+import { ItemRequirement } from '../requirement/ItemRequirement';
 import { NpcTalkedInCampaignRequirement } from '../requirement/NpcTalkedInCampaignRequirement';
 import { campaignStates, checkCampaigns, loadCampaigns } from './campaignStore';
+import { addItem } from './inventoryStore';
 import { incrementDungeonCompletions, loadStatistics } from './statisticsStore';
 
 function stubCampaign(overrides: Partial<Campaign> = {}): Campaign {
@@ -146,6 +148,25 @@ describe('checkCampaigns', () => {
     incrementDungeonCompletions('test_dungeon_sortie');
 
     expect(dungeonReq.isCompleted()).toBe(true);
+  });
+
+  it('advances mission when ItemRequirement is met', () => {
+    const campaign = stubCampaign({
+      id: 'item_campaign',
+      missions: [
+        new Mission({ id: 'collect_items', goals: [new ItemRequirement('core_saver', 3)] }),
+        new Mission({ id: 'done', goals: [new NpcTalkedInCampaignRequirement('item_campaign', 'npc')] }),
+      ],
+    });
+    loadCampaigns(
+      { item_campaign: campaign },
+      { item_campaign: { currentMission: { goalState: [], id: 'collect_items' }, status: CampaignStatus.Started } }
+    );
+
+    addItem('core_saver', 3);
+    checkCampaigns();
+
+    expect(campaignStates()['item_campaign']?.currentMission.id).toBe('done');
   });
 
   it('handles DungeonCompletionRequirement inside AllOfRequirement', () => {


### PR DESCRIPTION
## Summary
- Fixes #228: `checkCampaigns()` was not called after `buyItem()` in the shop, so missions with `ItemRequirement` (like `unia_trials` requiring 50 `core_saver`) would not advance until another event triggered `checkCampaigns`.
- Added a unit test for mission advancement via `ItemRequirement`.

## Test plan
- [x] Unit test: `advances mission when ItemRequirement is met`
- [x] Manual: buy the last required `core_saver` in the shop and verify the mission advances immediately without needing to talk to an NPC or win a battle