### PR TITLE
Fix dungeon active lines showing wrong connections (#227)

### DIFF
--- a/src/dungeon/DungeonMapScreen.test.ts
+++ b/src/dungeon/DungeonMapScreen.test.ts
@@ -73,6 +73,39 @@ describe('Dungeon layer advance animation', () => {
     expect(visible[1].depth).toBe(1);
   });
 
+  it('only the completed node from previous layer should drive active connections', () => {
+    startSortie(DUMMY_SORTIE, 100, 100);
+    const run = dungeonRun()!;
+
+    const completedNodeId = ENTRY_NODE_ID;
+    const prevLayer = run.graph[run.currentDepth - 1];
+    const completedNode = prevLayer.nodes.find((n) => run.nodeResults[n.id] === 'completed');
+
+    expect(completedNode).toBeDefined();
+    expect(completedNode!.id).toBe(completedNodeId);
+
+    const otherNodes = prevLayer.nodes.filter((n) => n.id !== completedNodeId);
+    for (const node of otherNodes) {
+      expect(run.nodeResults[node.id]).toBeUndefined();
+    }
+  });
+
+  it('after advancing, completed node from new previous layer drives active connections', () => {
+    startSortie(DUMMY_SORTIE, 100, 100);
+    const run = dungeonRun()!;
+
+    const firstLayerNode = run.graph[1].nodes[0];
+    markNodeCompleted(firstLayerNode.id);
+    advanceLayer();
+
+    const updated = dungeonRun()!;
+    const prevLayer = updated.graph[updated.currentDepth - 1];
+    const completedNode = prevLayer.nodes.find((n) => updated.nodeResults[n.id] === 'completed');
+
+    expect(completedNode).toBeDefined();
+    expect(completedNode!.id).toBe(firstLayerNode.id);
+  });
+
   it('endDungeon clears isLayerAdvancing', () => {
     startSortie(DUMMY_SORTIE, 100, 100);
     setIsLayerAdvancing(true);

--- a/src/dungeon/DungeonMapScreen.tsx
+++ b/src/dungeon/DungeonMapScreen.tsx
@@ -98,14 +98,14 @@ const DungeonMapScreen: Component<Props> = (props) => {
           if (!toEl) {continue;}
           const toRect = toEl.getBoundingClientRect();
 
-          const isFirstLayer = layers[i].depth === r.currentDepth;
+          const isActiveConnection = node.id === lastCompletedNodeId();
 
           const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
           line.setAttribute('x1', String(fromRect.left + fromRect.width / 2 - containerRect.left));
           line.setAttribute('y1', String(fromRect.top + fromRect.height / 2 - containerRect.top));
           line.setAttribute('x2', String(toRect.left + toRect.width / 2 - containerRect.left));
           line.setAttribute('y2', String(toRect.top + toRect.height / 2 - containerRect.top));
-          line.setAttribute('class', isFirstLayer ? 'connection-active' : 'connection-inactive');
+          line.setAttribute('class', isActiveConnection ? 'connection-active' : 'connection-inactive');
           svgRef.appendChild(line);
         }
       }


### PR DESCRIPTION
## Summary
- Fixed dungeon map connection lines highlighting the wrong paths
- Previously, all connections from an incorrect layer were marked as active (red)
- Now only the connections from the last completed node to the selectable nodes are highlighted

Closes #227

## Test plan
- [x] Added 2 unit tests verifying the completed node drives active connections
- [x] All 611 tests pass
- [x] Manual: enter a dungeon, confirm only lines from the completed node to selectable nodes are red