### PR TITLE
Fix scan not working in WildBossBattle (#229)

### DIFF
--- a/src/game/WildBossBattle.test.ts
+++ b/src/game/WildBossBattle.test.ts
@@ -38,6 +38,13 @@ describe('WildBossBattle', () => {
     expect(spy).toHaveBeenCalledOnce();
   });
 
+  it('attempts scan on enemy defeat', () => {
+    const battle = new WildBossBattle(PLAYER_STATS, ZOIDS);
+    const spy = vi.spyOn(battle as never, 'tryScan');
+    battle['onEnemyDefeated']();
+    expect(spy).toHaveBeenCalledOnce();
+  });
+
   it('calls onDefeat when player health reaches zero', () => {
     const battle = new WildBossBattle(PLAYER_STATS, [{ attackOverride: 9999, id: 'gator', level: 99, maxHealthOverride: 50 }]);
     const spy = vi.fn();

--- a/src/game/WildBossBattle.ts
+++ b/src/game/WildBossBattle.ts
@@ -2,6 +2,7 @@ import type { PlayerStats } from '../models/Player';
 import type { ZoidBlueprint } from '../models/Zoid';
 import { spawnZoid, buildZoid, ZoidResearchStatus } from '../models/Zoid';
 import { addFragments } from '../store/nurturingStore';
+import { resetScanAfterBattle } from '../store/scanStore';
 import { updateZoidResearch } from '../store/zoidResearchStore';
 import {
   setEnemyZoid,
@@ -36,6 +37,8 @@ export class WildBossBattle extends BaseBattle {
   }
 
   protected onEnemyDefeated(): void {
+    this.tryScan();
+    resetScanAfterBattle();
     addFragments(this.fragmentYield);
     if (this.currentEnemyIndex < this.zoids.length - 1) {
       this.nextEnemy();


### PR DESCRIPTION
## Summary
- `WildBossBattle.onEnemyDefeated()` now calls `tryScan()` and `resetScanAfterBattle()`, matching the pattern used by `Battle` and `DungeonBattle`
- Fixes the dungeon event `downed_zoid` cannon_tortoise not yielding Z-data when scanned

## Test plan
- [x] Unit test added verifying `tryScan()` is called on enemy defeat
- [x] Full test suite passes (612 tests)
- [x] Load save, enter Sommerso dungeon, trigger downed_zoid event → fight cannon_tortoise with scanner on → verify Z-data is obtained

Closes #229