### PR TITLE
Add subtract buttons and editable quantity to shop (#232)

### DIFF
--- a/src/ui/ShopPanel.tsx
+++ b/src/ui/ShopPanel.tsx
@@ -69,8 +69,26 @@ const ShopPanel: Component<ShopPanelProps> = (props) => {
         </div>
         <div class="shop-buy-section">
           <div class="shop-amount-row">
+            <button class="shop-amount-btn" onClick={() => setAmount((a) => Math.max(1, a - 10))}>-10</button>
             <button class="shop-amount-btn" onClick={() => setAmount((a) => Math.max(1, a - 1))}>−</button>
-            <span class="shop-amount-value">{amount()}</span>
+            <input
+              class="shop-amount-input"
+              type="number"
+              min="1"
+              value={amount()}
+              onInput={(e) => {
+                const val = parseInt(e.currentTarget.value);
+                if (!Number.isNaN(val) && val >= 1) {
+                  setAmount(val);
+                }
+              }}
+              onBlur={(e) => {
+                const val = parseInt(e.currentTarget.value);
+                if (Number.isNaN(val) || val < 1) {
+                  setAmount(1);
+                }
+              }}
+            />
             <button class="shop-amount-btn" onClick={() => setAmount((a) => a + 1)}>+</button>
             <button class="shop-amount-btn" onClick={() => setAmount((a) => a + 10)}>+10</button>
             <button class="shop-amount-btn" onClick={() => setAmount(Math.max(1, maxAffordable()))}>{t('ui:max')}</button>

--- a/src/ui/shop.css
+++ b/src/ui/shop.css
@@ -203,12 +203,24 @@
   background: var(--theme-button-hover);
 }
 
-.shop-amount-value {
+.shop-amount-input {
+  appearance: textfield;
+  background: transparent;
+  border: 1px solid var(--theme-border);
+  border-radius: 4px;
   color: #fff;
   font-size: 1rem;
   font-weight: bold;
-  min-width: 2.5rem;
+  min-width: 3rem;
+  padding: 0.2rem 0.3rem;
   text-align: center;
+  width: 4rem;
+}
+
+.shop-amount-input::-webkit-inner-spin-button,
+.shop-amount-input::-webkit-outer-spin-button {
+  appearance: none;
+  margin: 0;
 }
 
 .shop-total-row {


### PR DESCRIPTION
## Summary
- Add **-10** button to the shop quantity row
- Replace static quantity display with an editable `<input type="number">` so users can type a value directly
- Validate input: clamp to minimum 1, reset on blur if invalid
- Hide native number spinners for consistent styling

Closes #232

## Test plan
- [x] Open the shop and verify all buttons work: -10, −, +, +10, max
- [x] Verify -10 and − never go below 1
- [x] Click the quantity field and type a number — confirm it updates the total
- [x] Type invalid values (0, negative, empty) and blur — confirm it resets to 1