### PR TITLE
Add version number to settings menu

### DIFF
--- a/src/ui/SettingsMenu.tsx
+++ b/src/ui/SettingsMenu.tsx
@@ -82,6 +82,7 @@ const SettingsMenu: Component = () => {
               <DevFactionTools />
             </Match>
           </Switch>
+          <span class="settings-version">v{__APP_VERSION__}</span>
         </div>
       </Show>
     </div>

--- a/src/ui/settings.css
+++ b/src/ui/settings.css
@@ -141,6 +141,14 @@
   font-size: 1.2rem;
 }
 
+.settings-version {
+  color: #666;
+  display: block;
+  font-size: 0.7rem;
+  margin-top: 0.5rem;
+  text-align: center;
+}
+
 .reset-overlay {
   align-items: center;
   background: rgb(0 0 0 / 60%);


### PR DESCRIPTION
## Summary
- Show the current app version (`v{__APP_VERSION__}`) as a footer in the settings dropdown menu
- Visible in all menu views (main, language, dev)

## Test plan
- [x] Open settings menu and verify version appears at the bottom
- [x] Switch between menu views (language, dev) and confirm version stays visible
- [x] Verify version matches `package.json`