### PR TITLE
Add Umami analytics tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,8 @@
     <meta name="twitter:title" content="Zoids Sleeper" />
     <meta name="twitter:description" content="Zoids Sleeper - A Zoids idle clicker game" />
     <meta name="twitter:image" content="/images/background/thumbnail.jpg" />
+
+    <script defer src="https://stats.thecorezi.com/script.js" data-website-id="a7f5a7c2-87db-49c5-a695-70815693ba19" data-domains="elawdk.com,zoidssleeper.com"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import {
   Show,
   Switch,
 } from 'solid-js';
+import { CampaignStatus } from './campaign/Campaign';
 import DungeonBattleScreen from './dungeon/DungeonBattleScreen';
 import DungeonEventScreen from './dungeon/DungeonEventScreen';
 import DungeonMapScreen from './dungeon/DungeonMapScreen';
@@ -15,6 +16,7 @@ import DungeonSupplyScreen from './dungeon/DungeonSupplyScreen';
 import { DungeonPhase, dungeonPhase, isDungeonActive } from './dungeon/dungeonStore';
 import { Game } from './game/Game';
 import { t } from './i18n';
+import { AnalyticsSource, trackCampaignProgress, trackFaction } from './lib/analytics';
 import WorldMap from './map/WorldMap';
 import { EvolutionPopupImage, PopupMessage, PopupType } from './models/PopupMessage';
 import EvolutionPopupImageView from './ui/EvolutionPopupImageView';
@@ -57,7 +59,7 @@ import { getZoidImage, getZoidName, ZOID_LIST } from './models/Zoid';
 import { buyItem } from './store/inventoryStore';
 import { addTypedCore } from './store/zoidCoreStore';
 import { grantReward } from './reward';
-import { checkCampaigns, isMissionCompleted } from './store/campaignStore';
+import { campaignStates, checkCampaigns, isMissionCompleted } from './store/campaignStore';
 import { isSpeciesInTank } from './store/nurturingStore';
 import { addZoidToArmy, party } from './store/partyStore';
 import { addCurrency, getCurrency } from './store/walletStore';
@@ -85,6 +87,13 @@ const App: Component = () => {
   onMount(() => {
     game = new Game();
     game.start();
+    const stats = playerStats();
+    if (stats) {trackFaction(stats.faction, AnalyticsSource.Session);}
+    for (const [campaignId, state] of Object.entries(campaignStates())) {
+      if (state.status === CampaignStatus.Inactive) {continue;}
+      const progress = state.status === CampaignStatus.Completed ? CampaignStatus.Completed : state.currentMission.id;
+      trackCampaignProgress(campaignId, progress, AnalyticsSource.Session);
+    }
   });
 
   onCleanup(() => {

--- a/src/lib/analytics.test.ts
+++ b/src/lib/analytics.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AnalyticsSource, trackCampaignProgress, trackFaction } from './analytics';
+
+const track = vi.fn();
+
+beforeEach(() => {
+  track.mockClear();
+  window.umami = { track };
+});
+
+afterEach(() => {
+  delete window.umami;
+});
+
+describe('analytics', () => {
+  it('tracks the current faction', () => {
+    trackFaction('helic_republic');
+
+    expect(track).toHaveBeenCalledWith('player-faction', {
+      faction: 'helic_republic',
+      source: AnalyticsSource.Change,
+    });
+  });
+
+  it('tracks campaign progress', () => {
+    trackCampaignProgress('test_campaign', 'current_mission');
+
+    expect(track).toHaveBeenCalledWith('campaign-progress', {
+      campaign: 'test_campaign',
+      progress: 'current_mission',
+      source: AnalyticsSource.Change,
+    });
+  });
+
+  it('tracks campaign progress from a session', () => {
+    trackCampaignProgress('started_campaign', 'current_mission', AnalyticsSource.Session);
+
+    expect(track).toHaveBeenCalledWith('campaign-progress', {
+      campaign: 'started_campaign',
+      progress: 'current_mission',
+      source: AnalyticsSource.Session,
+    });
+  });
+
+  it('does not fail when Umami is unavailable', () => {
+    delete window.umami;
+
+    expect(() => trackFaction('neutral')).not.toThrow();
+  });
+});

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,26 @@
+export const AnalyticsSource = {
+  Change: 'change',
+  Session: 'session',
+} as const;
+
+export type AnalyticsSource = (typeof AnalyticsSource)[keyof typeof AnalyticsSource];
+
+declare global {
+  interface Window {
+    umami?: {
+      track: (name: string, data?: Record<string, string>) => void;
+    };
+  }
+}
+
+export function trackFaction(faction: string, source: AnalyticsSource = AnalyticsSource.Change): void {
+  track('player-faction', { faction, source });
+}
+
+export function trackCampaignProgress(campaign: string, progress: string, source: AnalyticsSource = AnalyticsSource.Change): void {
+  track('campaign-progress', { campaign, progress, source });
+}
+
+function track(name: string, data: Record<string, string>): void {
+  window.umami?.track(name, data);
+}

--- a/src/store/campaignStore.ts
+++ b/src/store/campaignStore.ts
@@ -1,6 +1,7 @@
 import { createSignal } from 'solid-js';
 import { CampaignStatus, type Campaign, type CampaignSaveData } from '../campaign/Campaign';
 import { t } from '../i18n';
+import { trackCampaignProgress } from '../lib/analytics';
 import { PopupMessage, PopupType } from '../models/PopupMessage';
 import { NpcTalkedInCampaignRequirement } from '../requirement/NpcTalkedInCampaignRequirement';
 import { showPopup } from './gameStore';
@@ -29,6 +30,7 @@ function advanceMission(campaignId: string): void {
     : { currentMission: campaign.missions[nextIndex].toSaveData(), missionNpcFlags: buildNpcFlags(campaign, nextIndex), status: CampaignStatus.Started };
 
   setCampaignStates((prev) => ({ ...prev, [campaignId]: newState }));
+  trackCampaignProgress(campaignId, completed ? CampaignStatus.Completed : newState.currentMission.id);
 
   campaign.missions[currentIndex]?.onComplete?.();
 
@@ -130,10 +132,16 @@ function markNpcTalked(npcId: string): void {
 function startCampaign(id: string): void {
   const campaign = campaigns[id];
   if (!campaign) {return;}
+  const newState: CampaignSaveData = {
+    currentMission: campaign.missions[0].toSaveData(),
+    missionNpcFlags: buildNpcFlags(campaign, 0),
+    status: CampaignStatus.Started,
+  };
   setCampaignStates((prev) => ({
     ...prev,
-    [id]: { currentMission: campaign.missions[0].toSaveData(), missionNpcFlags: buildNpcFlags(campaign, 0), status: CampaignStatus.Started },
+    [id]: newState,
   }));
+  trackCampaignProgress(id, newState.currentMission.id);
 }
 
 function forceSetMission(campaignId: string, missionId: string): void {

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -1,4 +1,5 @@
 import { createMemo, createSignal } from 'solid-js';
+import { trackFaction } from '../lib/analytics';
 import { FACTIONS, type Faction } from '../models/Faction';
 import { PopupMessage, PopupType } from '../models/PopupMessage';
 import { Rank } from '../models/Rank';
@@ -147,7 +148,9 @@ function getPlayerRank(): Rank {
 }
 
 function setPlayerFaction(faction: Faction): void {
+  const previousFaction = playerStats()?.faction;
   setPlayerStats((prev) => prev ? { ...prev, faction } : prev);
+  if (previousFaction && previousFaction !== faction) {trackFaction(faction);}
   const factionData = FACTIONS[faction];
   showPopup(new PopupMessage(
     t(`factions:${faction}`),


### PR DESCRIPTION
### Summary
Adds Umami analytics to Zoids Sleeper so page visits, player faction, and campaign progress can be measured across the current and future production domains. Tracking remains anonymous and uses stable game identifiers instead of translated labels.

### Why
The game currently has no production usage analytics. This adds aggregate visibility into visits and player progression without changing save data or introducing user profiles.

### What changed
- Loaded the Umami tracker from stats.thecorezi.com and restricted it to elawdk.com and zoidssleeper.com
- Added a dependency-free wrapper for player-faction and campaign-progress events
- Sent restored faction and active or completed campaign state when a session starts
- Sent updates when a faction changes or a campaign starts, advances, or completes
- Added coverage for event payloads and unavailable tracker behavior

### How to test
1. Publish the branch to an environment served from elawdk.com or zoidssleeper.com.
2. Open Zoids Sleeper and confirm a pageview appears for the new Umami website.
3. Load an existing save and confirm player-faction and campaign-progress events use source=session.
4. Change faction or advance a campaign and confirm the new event uses source=change.
5. Confirm inactive campaigns are not emitted during session startup.