### PR TITLE
Fix Zoid detail modal for nurturing tank

### DIFF
--- a/src/store/nurturingStore.ts
+++ b/src/store/nurturingStore.ts
@@ -63,6 +63,13 @@ function getAvailableTransportZoids(): string[] {
   return Object.keys(TRANSPORT_ZOID_BONUSES).filter((id) => owned.includes(id));
 }
 
+function getOwnedZoidInTank(zoidSpeciesId: string): OwnedZoid | undefined {
+  const slot = tankSlots().find((slot) =>
+    slot.source === TankSlotSource.Reborn && slot.zoidSpeciesId === zoidSpeciesId
+  );
+  return slot?.source === TankSlotSource.Reborn ? slot.ownedZoid : undefined;
+}
+
 function getTransportBonus(): TransportZoidBonus {
   const id = transportZoidId();
   return id ? TRANSPORT_ZOID_BONUSES[id] ?? NO_TRANSPORT_BONUS : NO_TRANSPORT_BONUS;
@@ -175,4 +182,4 @@ function selectTransportZoid(newId: string | null): void {
   }
 }
 
-export { addFragments, completeSlot, getAvailableSlotCount, getAvailableTransportZoids, getTransportBonus, isCoreNurtured, isSpeciesInTank, loadTankSlots, loadTransportZoidId, placeCore, placeReborn, placeStatue, removeStatueSlot, selectTransportZoid, tankSlots, transportZoidId };
+export { addFragments, completeSlot, getAvailableSlotCount, getAvailableTransportZoids, getOwnedZoidInTank, getTransportBonus, isCoreNurtured, isSpeciesInTank, loadTankSlots, loadTransportZoidId, placeCore, placeReborn, placeStatue, removeStatueSlot, selectTransportZoid, tankSlots, transportZoidId };

--- a/src/ui/ZoidDetailModal.test.tsx
+++ b/src/ui/ZoidDetailModal.test.tsx
@@ -1,0 +1,60 @@
+import { render } from 'solid-js/web';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { changeLocale } from '../i18n';
+import { experienceForLevel } from '../models/LevelType';
+import { getZoidById, ZoidResearchStatus } from '../models/Zoid';
+import { loadTankSlots } from '../store/nurturingStore';
+import { setParty } from '../store/partyStore';
+import { TankSlotSource } from '../store/TankSlot';
+import ZoidDetailModal from './ZoidDetailModal';
+
+const ZOID_ID = 'merda';
+let dispose: (() => void) | undefined;
+
+beforeEach(() => {
+  changeLocale('en');
+  setParty({ commanderZoidId: 'gator', zoids: [{ experience: 0, id: 'gator' }] });
+  loadTankSlots([{
+    fragments: 0,
+    fragmentsRequired: 400,
+    ownedZoid: {
+      copies: 2,
+      experience: experienceForLevel(100, getZoidById(ZOID_ID).levelType),
+      id: ZOID_ID,
+      rebornBonusPercent: 15,
+      rebornCount: 3,
+    },
+    source: TankSlotSource.Reborn,
+    zoidSpeciesId: ZOID_ID,
+  }]);
+});
+
+afterEach(() => {
+  dispose?.();
+  dispose = undefined;
+  document.body.replaceChildren();
+  loadTankSlots([]);
+  vi.restoreAllMocks();
+});
+
+describe('ZoidDetailModal', () => {
+  it('shows owned stats when the zoid is in the nurturing tank', () => {
+    const root = document.createElement('div');
+    document.body.append(root);
+    dispose = render(() => (
+      <ZoidDetailModal id={ZOID_ID} onClose={vi.fn()} status={ZoidResearchStatus.Created} />
+    ), root);
+
+    const stats = Object.fromEntries(
+      [...root.querySelectorAll('.archive-detail-stat')].map((row) => [
+        row.querySelector('.archive-detail-stat-label')?.textContent,
+        row.querySelector('.archive-detail-stat-value')?.textContent,
+      ])
+    );
+    expect(stats['Times Deployed']).toBe('2');
+    expect(stats['Times Nurtured']).toBe('3');
+    expect(stats['Research Bonus']).toBe('15%');
+    expect(stats['Current Attack']).toBeDefined();
+    expect(stats['Current HP']).toBeDefined();
+  });
+});

--- a/src/ui/ZoidDetailModal.tsx
+++ b/src/ui/ZoidDetailModal.tsx
@@ -12,6 +12,7 @@ import {
   ZoidResearchStatus,
 } from '../models/Zoid';
 import { playerStats } from '../store/gameStore';
+import { getOwnedZoidInTank } from '../store/nurturingStore';
 import { party } from '../store/partyStore';
 import { getSpeciesDefeats } from '../store/statisticsStore';
 import { getZoidResearch } from '../store/zoidResearchStore';
@@ -38,7 +39,7 @@ const ZoidDetailModal: Component<ZoidDetailModalProps> = (props) => {
   const locations = () => getZoidLocations(props.id);
   const isRevealed = () => props.status !== ZoidResearchStatus.Seen;
   const isCreated = () => props.status === ZoidResearchStatus.Created;
-  const ownedZoid = () => party().zoids.find((z) => z.id === props.id);
+  const ownedZoid = () => party().zoids.find((z) => z.id === props.id) ?? getOwnedZoidInTank(props.id);
   const ownedLevel = () => { const oz = ownedZoid(); return oz ? getOwnedZoidLevel(oz) : null; };
   const currentAtk = () => { const oz = ownedZoid(); const lv = ownedLevel(); return oz && lv ? buildZoid({ id: props.id, level: lv, rebornBonusPercent: oz.rebornBonusPercent }).attack : null; };
   const currentHp = () => { const oz = ownedZoid(); const lv = ownedLevel(); return oz && lv ? buildZoid({ id: props.id, level: lv, rebornBonusPercent: oz.rebornBonusPercent }).maxHealth : null; };
@@ -156,8 +157,8 @@ const ZoidDetailModal: Component<ZoidDetailModalProps> = (props) => {
                     {statRow(t('ui:archive_defeated'), getSpeciesDefeats(props.id))}
                     <Show when={isCreated()}>
                       {statRow(t('ui:archive_deployed'), ownedZoid()?.copies ?? 1)}
-                      {statRow(t('ui:archive_times_nurtured'), ownedZoid()!.rebornCount ?? 0)}
-                      {statRow(t('ui:archive_research_bonus'), `${ownedZoid()!.rebornBonusPercent ?? 0}%`)}
+                      {statRow(t('ui:archive_times_nurtured'), ownedZoid()?.rebornCount ?? 0)}
+                      {statRow(t('ui:archive_research_bonus'), `${ownedZoid()?.rebornBonusPercent ?? 0}%`)}
                     </Show>
                     {statRow(t('ui:stat_core_fragments'), zoid().coreFragments)}
                   </div>


### PR DESCRIPTION
## Summary

- Resolve owned Zoid data from reborn nurturing tank slots.
- Display preserved stats and reborn values in the Zi Archive.
- Handle missing owned Zoid data without crashing the detail modal.
- Add a regression test for Zoids in the nurturing tank.

## Testing

- `npm test`
- `npm run lint`
- `npm run build`

Closes #249